### PR TITLE
0.1.0 commit

### DIFF
--- a/Helm/README.md
+++ b/Helm/README.md
@@ -1,2 +1,85 @@
-## To Do 
-    Add installation instructions and other details related to Helm Chart
+# OpenSearch Helm
+A Helm chart for deploying an configurable highly available Opensearch cluster.
+
+## Current Features
+- Deploys a scalable number of Opensearch master nodes
+- Configurable and scalable number of Opensearch nodes
+  - A `node` object is defined in the `values.yaml` as an array, as many node types or variations can be generated as desired. 
+- Node objects can have the following roles assigned the following roles:
+  - master - Allows additional masters if desired
+  - data - This can be further broken down into various tiers:
+    - data_content
+    - data_hot 
+    - data_warm
+    - data_cold
+    - data_frozen
+  - ingest - Client facing nodes
+  - remote_cluster_client - Cross-Cluster query
+
+
+## Future Features
+- Ingress management
+- Privileged Daemonset for configuring required settings such as vm.max_map_count
+  - Running this standalone means there is no privilege exposure in the Opensearch runtimes
+- RBAC for the Opensearch runtimes  
+- Authentication and Authorization configuration via the Helm Chart:
+  - LDAP
+  - SAML
+  - OIDC
+- Pre-set health checks:
+  - Liveness Probes
+  - Readiness Probes
+- Pre-set Affinity rules:
+  - Soft or hard anti-affinities
+- Cert-Manager integration:
+  - Pre-installed or new installation for managing Opensearch TLS
+- Prometheus 
+  - Chart installed exporter with configuration available
+  - Optional Grafana deployment
+
+---
+
+## Getting Started
+
+### Host Pre-Requisites
+1. Set the `vm.max_map_count` to 262144, via `sysctl vm.max_map_count=262144` or editing `/etc/sysctl.conf`
+
+### Kubernetes Pre-Requisites
+1. Certificate objects created if not using Cert-Manager (TBD), see TLS Guide below for an openssl demonstration.
+
+### Deployment
+1. Create the namespace `kubectl create namespace <OPENSEARCH_NAMESPACE>`
+2. Clone the repository `git clone https://github.com/iron-rain/opensearch-devops.git`
+3. `cd opensearch-devops/Helm`
+4. `helm upgrade --install opensearch ./ -n <OPENSEARCH_NAMESPACE>`
+
+---
+
+## Examples
+1. OpenSSL Certificate Generation
+
+    ### Create the Root CA
+    `openssl genrsa -des3 -out ca.key 2048`
+
+    `openssl req -x509 -new -nodes -key ca.key -sha256 -days 365 -out ca.crt -subj "/CN=opensearch"`
+
+    ### Transport Certificates
+    `openssl req -out transport.csr -newkey rsa:2048 -nodes -keyout transport.key -subj "/CN=nodes"`
+
+    `openssl x509 -req -in transport.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out transport.crt -days 365 -sha256`
+
+    `kubectl create secret generic transport-tls --from=file=tls.crt=./transport.crt --from-file=tls.key=./transport.key --from-file=ca.crt=./ca.crt -n <OPENSEARCH_NAMESPACE>`
+
+    ### Rest Certificates
+    `openssl req -out rest.csr -newkey rsa:2048 -nodes -keyout rest.key -subj "/CN=rest"`
+
+    `openssl x509 -req -in rest.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out rest.crt -days 365 -sha256`
+
+    `kubectl create secret generic rest-tls --from-file=tls.crt=./rest.crt --from-file=tls.key=./rest.key --from-file=ca.crt=./ca.crt -n <OPENSEARCH_NAMESPACE>`
+
+    ### Admin Certificates
+    `openssl req -out admin.csr -newkey rsa:2048 -nodes -keyout admin.key -subj "/CN=admin"`
+
+    `openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out admin.crt -days 365 -sha256`
+
+    `kubectl create secret generic admin-tls --from-file=tls.crt=./admin.crt --from-file=tls.key=./admin.key --from-file=ca.crt=./ca.crt -n <OPENSEARCH_NAMESPACE>`

--- a/Helm/opensearch/.helmignore
+++ b/Helm/opensearch/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Helm/opensearch/Chart.yaml
+++ b/Helm/opensearch/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: opensearch
+description: A Helm chart for Opensearch on Kubernetes
+
+type: application
+
+version: 0.1.0
+
+appVersion: "1.0.0-rc1"
+
+sources:
+  - https://opensearch.org/
+
+dependencies:
+#- name: opensearch-dashboards
+  #version: 0.1.0
+  #repository: TBD
+  #condition: opensearch-dashboards.enabled
+
+maintainers:
+  - name: Andrew Young
+    email: adyoung@ironrain.io
+    

--- a/Helm/opensearch/templates/_helpers.tpl
+++ b/Helm/opensearch/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "opensearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "opensearch.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "opensearch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "opensearch.labels" -}}
+helm.sh/chart: {{ include "opensearch.chart" . }}
+{{ include "opensearch.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "opensearch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opensearch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "opensearch.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "opensearch.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "master-nodes" -}}
+{{- template "opensearch.fullname" . -}}-master
+{{- end -}}
+
+
+{{- define "initial-master-nodes" -}}
+{{- $replicas := .Values.opensearch.master.replicas | int }}
+  {{- range $i, $e := untilStep 0 $replicas 1 -}}
+    {{ template "master-nodes" $ }}-{{ $i }},
+  {{- end -}}
+{{- end -}}

--- a/Helm/opensearch/templates/master_pdb.yaml
+++ b/Helm/opensearch/templates/master_pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.opensearch.master.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opensearch.fullname" .}}-master-pod-disruption-budget
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opensearch.labels" . | indent 4 }}
+spec:
+{{- if .Values.opensearch.master.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.opensearch.master.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.opensearch.master.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.opensearch.master.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opensearch.fullname" .}}
+      role: master
+{{ include "opensearch.selectorLabels" . | indent 6 }}
+{{- end }}

--- a/Helm/opensearch/templates/master_service.yaml
+++ b/Helm/opensearch/templates/master_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "opensearch.fullname" .}}-master-service
+  labels:
+{{ include "opensearch.labels" . | indent 4 }}
+spec:
+  selector:
+    app: {{ template "opensearch.fullname" .}}
+    role: master
+{{ include "opensearch.selectorLabels" . | indent 4 }}
+  ports:
+  - name: tcp-9200
+    port: 9200
+    targetPort: 9200
+  - name: tcp-9300
+    port: 9300
+    targetPort: 9300    

--- a/Helm/opensearch/templates/master_statefulset.yaml
+++ b/Helm/opensearch/templates/master_statefulset.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "opensearch.fullname" .}}-master
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "opensearch.fullname" .}}
+      role: master
+{{ include "opensearch.selectorLabels" . | indent 6 }}
+  serviceName: {{ template "opensearch.fullname" .}}-master-service
+  replicas: {{ .Values.opensearch.master.replicas }}
+  template:
+    metadata:      
+      labels:
+        app: {{ template "opensearch.fullname" .}}
+        role: master
+{{ include "opensearch.selectorLabels" . | indent 8 }}
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.opensearch.master.securityContext.fsGroup }}        
+      containers:
+      - name: {{ template "opensearch.fullname" .}}-master
+        image: "{{ .Values.opensearch.global.registry }}/{{ .Values.opensearch.master.image.repository }}:{{ .Values.opensearch.master.image.tag }}"        
+        imagePullPolicy: {{ .Values.opensearch.master.imagePullPolicy }}
+        env:
+        - name: cluster.name
+          value: "{{ .Values.opensearch.global.clusterName }}"
+        - name: ROLES
+        {{- if .Values.opensearch.master.roles }}
+          value: "{{ join ", " .Values.opensearch.master.roles }}"
+        {{- else }}
+          value: ""
+        {{- end }}
+        - name: SEEDS
+          value: {{ template "opensearch.fullname" .}}-master-service
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: OPENSEARCH_JAVA_OPTS
+          value: {{ .Values.opensearch.master.javaOpts }}          
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name          
+{{- if .Values.opensearch.master.extraEnvs }}
+{{ toYaml .Values.opensearch.master.extraEnvs | indent 8 }}
+{{- end }}                
+        resources:
+          requests:
+            cpu: {{ .Values.opensearch.master.resources.requests.cpu }}
+            memory: {{ .Values.opensearch.master.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.opensearch.master.resources.limits.cpu }}
+            memory: {{ .Values.opensearch.master.resources.limits.memory }}            
+        ports:
+        - containerPort: 9200
+          name: tcp-9200
+        - containerPort: 9300
+          name: tcp-9300
+        securityContext:
+          runAsUser: {{ .Values.opensearch.master.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.opensearch.master.securityContext.runAsGroup }}
+          allowPrivilegeEscalation: {{ .Values.opensearch.master.securityContext.allowPrivilegeEscalation }}
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config        
+{{- if .Values.opensearch.master.persistence.enabled }}                  
+        - name: {{ template "opensearch.fullname" .}}-master-data
+          mountPath: /usr/share/opensearch/data
+{{- end }}
+        - name: transport-ssl
+          mountPath: /usr/share/opensearch/config/ssl/transport          
+        {{- if .Values.opensearch.global.ssl.rest.enabled }}
+        - name: rest-ssl
+          mountPath: /usr/share/opensearch/config/ssl/rest          
+        {{- end }}
+        {{- if .Values.opensearch.global.ssl.admin.enabled }}
+        - name: admin-ssl
+          mountPath: /usr/share/opensearch/config/ssl/admin          
+        {{- end }}       
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/jvm.options
+          subPath: jvm.options
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/log4j2.properties
+          subPath: log4j2.properties
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch-notebooks/notebooks.yml
+          subPath: notebooks.yml
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch-reports-scheduler/reports-scheduler.yml
+          subPath: reports-scheduler.yml
+        - name: opensearch-security
+          mountPath: /usr/share/opensearch/plugins/opensearch-security/securityconfig
+      terminationGracePeriodSeconds: 0 
+      volumes:
+      - name: config
+        emptyDir: {}
+      - name: opensearch-security
+        secret:
+          secretName: {{ .Values.opensearch.global.securityConfig.secretName }}
+      - name: transport-ssl
+        secret:
+          secretName: {{ .Values.opensearch.global.ssl.transport.secretName }}          
+      {{- if .Values.opensearch.global.ssl.rest.enabled }}
+      - name: rest-ssl
+        secret:
+          secretName: {{ .Values.opensearch.global.ssl.rest.secretName }}
+      {{- end }}
+      {{- if .Values.opensearch.global.ssl.admin.enabled }}    
+      - name: admin-ssl
+        secret:
+          secretName: {{ .Values.opensearch.global.ssl.admin.secretName }}              
+      {{- end }}     
+      - name: opensearch-config
+        configMap:
+          name: opensearch-config
+          items:
+          - path: opensearch.yml
+            key: opensearch.yml
+          - path: jvm.options
+            key: jvm.options
+          - path: log4j2.properties
+            key: log4j2.properties
+          - path: notebooks.yml
+            key: notebooks.yml
+          - path: reports-scheduler.yml
+            key: reports-scheduler.yml
+{{- if .Values.opensearch.master.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "opensearch.fullname" .}}-master-data
+    spec:
+      accessModes: {{ .Values.opensearch.master.persistence.accessModes }}
+      resources:
+        requests:
+          storage: {{ .Values.opensearch.master.persistence.size }}
+{{- end }}

--- a/Helm/opensearch/templates/nodes_pdb.yaml
+++ b/Helm/opensearch/templates/nodes_pdb.yaml
@@ -1,0 +1,23 @@
+{{- range .Values.opensearch.nodes }}
+{{- if .podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opensearch.fullname" $ }}-{{ .name }}-pod-disruption-budget  
+  labels:
+{{ include "opensearch.labels" $ | indent 4 }}
+spec:
+{{- if .podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opensearch.fullname" $ }}
+      role: {{ .name }}
+{{ include "opensearch.selectorLabels" $ | indent 6 }}
+{{- end }}
+---
+{{- end }}

--- a/Helm/opensearch/templates/nodes_service.yaml
+++ b/Helm/opensearch/templates/nodes_service.yaml
@@ -1,0 +1,21 @@
+{{- range .Values.opensearch.nodes }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "opensearch.fullname" $ }}-{{ .name }}-service
+  labels:
+{{ include "opensearch.labels" $ | indent 4 }}  
+spec:
+  selector:
+    app: {{ template "opensearch.fullname" $ }}
+    role: {{ .name }}
+{{ include "opensearch.selectorLabels" $ | indent 4 }}
+  ports:
+  - name: tcp-9200
+    port: 9200
+    targetPort: 9200
+  - name: tcp-9300
+    port: 9300
+    targetPort: 9300    
+---    
+{{- end }}

--- a/Helm/opensearch/templates/nodes_statefulset.yaml
+++ b/Helm/opensearch/templates/nodes_statefulset.yaml
@@ -1,0 +1,150 @@
+{{- range .Values.opensearch.nodes }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "opensearch.fullname" $ }}-{{ .name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "opensearch.fullname" $ }}
+      role: {{ .name }}
+{{ include "opensearch.selectorLabels" $ | indent 6 }}
+  serviceName: {{ template "opensearch.fullname" $ }}-{{ .name }}-service
+  replicas: {{ .replicas }}
+  template:
+    metadata:      
+      labels:
+        app: {{ template "opensearch.fullname" $ }}
+        role: {{ .name }}
+{{ include "opensearch.selectorLabels" $ | indent 8 }}
+    spec:
+      securityContext:
+        fsGroup: {{ .securityContext.fsGroup }}
+      containers:
+      - name: {{ template "opensearch.fullname" $ }}-{{ .name }}
+        image: "{{ $.Values.opensearch.global.registry }}/{{ .image.repository }}:{{ .image.tag }}"
+        imagePullPolicy: {{ .imagePullPolicy }}
+        env:
+        - name: cluster.name
+          value: "{{ $.Values.opensearch.global.clusterName }}"
+        - name: ROLES
+        {{- if .roles }}
+          value: "{{ join ", " .roles }}"
+        {{- else }}
+          value: ""
+        {{- end }}
+        - name: SEEDS
+          value: {{ template "opensearch.fullname" $ }}-master-service
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: OPENSEARCH_JAVA_OPTS
+          value: {{ .javaOpts }}          
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name          
+{{- if .extraEnvs }}
+{{ toYaml .extraEnvs | indent 8 }}
+{{- end }}                
+        resources:
+          requests:
+            cpu: {{ .resources.requests.cpu }}
+            memory: {{ .resources.requests.memory }}
+          limits:
+            cpu: {{ .resources.limits.cpu }}
+            memory: {{ .resources.limits.memory }}            
+        ports:
+        - containerPort: 9200
+          name: tcp-9200
+        - containerPort: 9300
+          name: tcp-9300
+        securityContext:
+          runAsUser: {{ .securityContext.runAsUser }}
+          runAsGroup: {{ .securityContext.runAsGroup }}
+          allowPrivilegeEscalation: {{ .securityContext.allowPrivilegeEscalation }}
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config        
+{{- if .persistence.enabled }}                  
+        - name: {{ template "opensearch.fullname" $ }}-{{ .name }}-data
+          mountPath: /usr/share/opensearch/data
+{{- end }}
+        - name: transport-ssl
+          mountPath: /usr/share/opensearch/config/ssl/transport          
+        {{- if $.Values.opensearch.global.ssl.rest.enabled }}
+        - name: rest-ssl
+          mountPath: /usr/share/opensearch/config/ssl/rest          
+        {{- end }}
+        {{- if $.Values.opensearch.global.ssl.admin.enabled }}
+        - name: admin-ssl
+          mountPath: /usr/share/opensearch/config/ssl/admin          
+        {{- end }}       
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/jvm.options
+          subPath: jvm.options
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/log4j2.properties
+          subPath: log4j2.properties
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch-notebooks/notebooks.yml
+          subPath: notebooks.yml
+        - name: opensearch-config
+          mountPath: /usr/share/opensearch/config/opensearch-reports-scheduler/reports-scheduler.yml
+          subPath: reports-scheduler.yml
+        - name: opensearch-security
+          mountPath: /usr/share/opensearch/plugins/opensearch-security/securityconfig
+      terminationGracePeriodSeconds: 0 
+      volumes:
+      - name: config
+        emptyDir: {}
+      - name: opensearch-security
+        secret:
+          secretName: {{ $.Values.opensearch.global.securityConfig.secretName }}
+      - name: transport-ssl
+        secret:
+          secretName: {{ $.Values.opensearch.global.ssl.transport.secretName }}          
+      {{- if $.Values.opensearch.global.ssl.rest.enabled }}
+      - name: rest-ssl
+        secret:
+          secretName: {{ $.Values.opensearch.global.ssl.rest.secretName }}
+      {{- end }}
+      {{- if $.Values.opensearch.global.ssl.admin.enabled }}    
+      - name: admin-ssl
+        secret:
+          secretName: {{ $.Values.opensearch.global.ssl.admin.secretName }}              
+      {{- end }}     
+      - name: opensearch-config
+        configMap:
+          name: opensearch-config
+          items:
+          - path: opensearch.yml
+            key: opensearch.yml
+          - path: jvm.options
+            key: jvm.options
+          - path: log4j2.properties
+            key: log4j2.properties
+          - path: notebooks.yml
+            key: notebooks.yml
+          - path: reports-scheduler.yml
+            key: reports-scheduler.yml
+{{- if .persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "opensearch.fullname" $ }}-{{ .name }}-data
+    spec:
+      accessModes: {{ .persistence.accessModes }}
+      resources:
+        requests:
+          storage: {{ .persistence.size }}
+{{- end }}
+---
+{{- end }}

--- a/Helm/opensearch/templates/opensearch_configmap.yaml
+++ b/Helm/opensearch/templates/opensearch_configmap.yaml
@@ -1,0 +1,155 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opensearch-config
+data:
+  log4j2.properties: |-
+{{ .Values.opensearch.global.log4jConfig | indent 4 }}
+  notebooks.yml: |-
+{{ .Values.opensearch.global.opensearchNotebook | indent 4 }}
+  reports-scheduler.yml: |-
+{{ .Values.opensearch.global.opensearchReports | indent 4 }}
+  opensearch.yml: |
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+
+    cluster.name: {{ .Values.opensearch.global.clusterName }}
+
+    {{ if .Values.opensearch.master.roles }}
+    cluster.initial_master_nodes: {{ template "initial-master-nodes" . }}
+    {{ else }}
+    # cluster.initial_master_nodes: {{ template "initial-master-nodes" . }}
+    {{ end }}
+
+    # # minimum_master_nodes need to be explicitly set when bound on a public IP
+    # # set to 1 to allow single node clusters
+        
+    {{ if .Values.opensearch.master.roles }}
+    # discovery.zen.minimum_master_nodes: 1
+    {{ else }}
+    discovery.zen.minimum_master_nodes: 1
+    {{ end }}
+    
+    node.roles: ${ROLES}
+    discovery.seed_hosts: ${SEEDS}
+
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    {{ if .Values.opensearch.master.roles }}
+    #discovery.type: single-node
+    {{ else }}
+    discovery.type: single-node
+    {{ end }}
+
+    plugins.security.ssl.transport.pemcert_filepath: ssl/transport/tls.crt
+    plugins.security.ssl.transport.pemkey_filepath: ssl/transport/tls.key
+    plugins.security.ssl.transport.pemtrustedcas_filepath: ssl/transport/ca.crt
+    plugins.security.ssl.transport.enforce_hostname_verification: false
+
+    {{ if .Values.opensearch.global.ssl.rest.enabled }}
+    plugins.security.ssl.http.enabled: true
+    plugins.security.ssl.http.pemcert_filepath: ssl/rest/tls.crt
+    plugins.security.ssl.http.pemkey_filepath: ssl/rest/tls.key
+    plugins.security.ssl.http.pemtrustedcas_filepath: ssl/rest/ca.crt
+    {{ end }}
+
+    plugins.security.allow_unsafe_democertificates: false
+    plugins.security.allow_default_init_securityindex: true
+
+    {{ if .Values.opensearch.global.ssl.admin.enabled }}
+    plugins.security.authcz.admin_dn:
+      - {{ .Values.opensearch.global.ssl.admin.commonName }}
+    {{ end }}
+
+    plugins.security.nodes_dn:
+      - {{ .Values.opensearch.global.ssl.transport.commonName }}
+
+    plugins.security.audit.type: internal_opensearch
+    plugins.security.enable_snapshot_restore_privilege: true
+    plugins.security.check_snapshot_restore_write_privileges: true
+    plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
+    plugins.security.system_indices.enabled: true
+    plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opendistro-asynchronous-search-response*"]
+    {{ .Values.opensearch.global.additionalConfig }}
+  jvm.options: |
+    ## JVM configuration
+
+    ################################################################
+    ## IMPORTANT: JVM heap size
+    ################################################################
+    ##
+    ## You should always set the min and max JVM heap
+    ## size to the same value. For example, to set
+    ## the heap to 4 GB, set:
+    ##
+    ## -Xms4g
+    ## -Xmx4g
+    ##
+    ## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+    ## for more information
+    ##
+    ################################################################
+
+    # Xms represents the initial size of total heap space
+    # Xmx represents the maximum size of total heap space
+
+    -Xms1g
+    -Xmx1g
+
+    ################################################################
+    ## Expert settings
+    ################################################################
+    ##
+    ## All settings below this section are considered
+    ## expert settings. Don't tamper with them unless
+    ## you understand what you are doing
+    ##
+    ################################################################
+
+    ## GC configuration
+    8-13:-XX:+UseConcMarkSweepGC
+    8-13:-XX:CMSInitiatingOccupancyFraction=75
+    8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+    ## G1GC Configuration
+    # NOTE: G1 GC is only supported on JDK version 10 or later
+    # to use G1GC, uncomment the next two lines and update the version on the
+    # following three lines to your version of the JDK
+    # 10-13:-XX:-UseConcMarkSweepGC
+    # 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+    14-:-XX:+UseG1GC
+    14-:-XX:G1ReservePercent=25
+    14-:-XX:InitiatingHeapOccupancyPercent=30
+
+    ## JVM temporary directory
+    -Djava.io.tmpdir=${OPENSEARCH_TMPDIR}
+
+    ## heap dumps
+
+    # generate a heap dump when an allocation from the Java heap fails
+    # heap dumps are created in the working directory of the JVM
+    -XX:+HeapDumpOnOutOfMemoryError
+
+    # specify an alternative path for heap dumps; ensure the directory exists and
+    # has sufficient space
+    -XX:HeapDumpPath=data
+
+    # specify an alternative path for JVM fatal error logs
+    -XX:ErrorFile=logs/hs_err_pid%p.log
+
+    ## JDK 8 GC logging
+    8:-XX:+PrintGCDetails
+    8:-XX:+PrintGCDateStamps
+    8:-XX:+PrintTenuringDistribution
+    8:-XX:+PrintGCApplicationStoppedTime
+    8:-Xloggc:logs/gc.log
+    8:-XX:+UseGCLogFileRotation
+    8:-XX:NumberOfGCLogFiles=32
+    8:-XX:GCLogFileSize=64m
+
+    # JDK 9+ GC logging
+    9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+    ## OpenDistro Performance Analyzer
+    -Dclk.tck=100
+    -Djdk.attach.allowAttachSelf=true
+    -Djava.security.policy=/usr/share/opensearch/plugins/opensearch-performance-analyzer/pa_config/opensearch_security.policy  

--- a/Helm/opensearch/templates/opensearch_secret.yaml
+++ b/Helm/opensearch/templates/opensearch_secret.yaml
@@ -1,0 +1,703 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.opensearch.global.securityConfig.secretName }}
+type: Opaque
+stringData:
+{{- if .Values.opensearch.global.securityConfig.overrides.action_groups }}
+  action_groups.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.action_groups | indent 4 }}
+{{- else }}
+  action_groups.yml: |
+    _meta:
+      type: "actiongroups"
+      config_version: 2  
+{{- end }}
+{{- if .Values.opensearch.global.securityConfig.overrides.audit }}
+  audit.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.audit | indent 4 }}  
+{{- else }}
+  audit.yml: |
+    _meta:
+      type: "audit"
+      config_version: 2
+
+    config:
+      # enable/disable audit logging
+      enabled: true
+
+      audit:
+        # Enable/disable REST API auditing
+        enable_rest: true
+
+        # Categories to exclude from REST API auditing
+        disabled_rest_categories:
+          - AUTHENTICATED
+          - GRANTED_PRIVILEGES
+
+        # Enable/disable Transport API auditing
+        enable_transport: true
+
+        # Categories to exclude from Transport API auditing
+        disabled_transport_categories:
+          - AUTHENTICATED
+          - GRANTED_PRIVILEGES
+
+        # Users to be excluded from auditing. Wildcard patterns are supported. Eg:
+        # ignore_users: ["test-user", "employee-*"]
+        ignore_users:
+          - kibanaserver
+
+        # Requests to be excluded from auditing. Wildcard patterns are supported. Eg:
+        # ignore_requests: ["indices:data/read/*", "SearchRequest"]
+        ignore_requests: []
+
+        # Log individual operations in a bulk request
+        resolve_bulk_requests: false
+
+        # Include the body of the request (if available) for both REST and the transport layer
+        log_request_body: true
+
+        # Logs all indices affected by a request. Resolves aliases and wildcards/date patterns
+        resolve_indices: true
+
+        # Exclude sensitive headers from being included in the logs. Eg: Authorization
+        exclude_sensitive_headers: true
+
+      compliance:
+        # enable/disable compliance
+        enabled: true
+
+        # Log updates to internal security changes
+        internal_config: true
+
+        # Log external config files for the node
+        external_config: false
+
+        # Log only metadata of the document for read events
+        read_metadata_only: true
+
+        # Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields. Eg:
+        # read_watched_fields: {
+        #   "twitter": ["message"]
+        #   "logs-*": ["id", "attr*"]
+        # }
+        read_watched_fields: {}
+
+        # List of users to ignore for read events. Wildcard patterns are supported. Eg:
+        # read_ignore_users: ["test-user", "employee-*"]
+        read_ignore_users:
+          - kibanaserver
+
+        # Log only metadata of the document for write events
+        write_metadata_only: true
+
+        # Log only diffs for document updates
+        write_log_diffs: false
+
+        # List of indices to watch for write events. Wildcard patterns are supported
+        # write_watched_indices: ["twitter", "logs-*"]
+        write_watched_indices: []
+
+        # List of users to ignore for write events. Wildcard patterns are supported. Eg:
+        # write_ignore_users: ["test-user", "employee-*"]
+        write_ignore_users:
+          - kibanaserver
+{{- end }}     
+{{- if .Values.opensearch.global.securityConfig.overrides.config }}
+  config.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.config | indent 4 }}       
+{{- else }}
+  config.yml: |
+    ---
+
+    # This is the main OpenSearch Security configuration file where authentication
+    # and authorization is defined.
+    #
+    # You need to configure at least one authentication domain in the authc of this file.
+    # An authentication domain is responsible for extracting the user credentials from
+    # the request and for validating them against an authentication backend like Active Directory for example.
+    #
+    # If more than one authentication domain is configured the first one which succeeds wins.
+    # If all authentication domains fail then the request is unauthenticated.
+    # In this case an exception is thrown and/or the HTTP status is set to 401.
+    #
+    # After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
+    # the roles from a given backend for the authenticated user.
+    #
+    # Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
+    #        http_enabled: true
+    #        transport_enabled: true
+    #
+    # For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
+    # find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
+    # If none can be found the user will be authenticated as an "anonymous" user. This user has always the username "anonymous"
+    # and one role named "anonymous_backendrole".
+    # If you enable anonymous authentication all HTTP authenticators will not challenge.
+    #
+    #
+    # Note: If you define more than one HTTP authenticators make sure to put non-challenging authenticators like "proxy" or "clientcert"
+    # first and the challenging one last.
+    # Because it's not possible to challenge a client with two different authentication methods (for example
+    # Kerberos and Basic) only one can have the challenge flag set to true. You can cope with this situation
+    # by using pre-authentication, e.g. sending a HTTP Basic authentication header in the request.
+    #
+    # Default value of the challenge flag is true.
+    #
+    #
+    # HTTP
+    #   basic (challenging)
+    #   proxy (not challenging, needs xff)
+    #   kerberos (challenging)
+    #   clientcert (not challenging, needs https)
+    #   jwt (not challenging)
+    #   host (not challenging) #DEPRECATED, will be removed in a future version.
+    #                          host based authentication is configurable in roles_mapping
+
+    # Authc
+    #   internal
+    #   noop
+    #   ldap
+
+    # Authz
+    #   ldap
+    #   noop
+
+
+
+    _meta:
+      type: "config"
+      config_version: 2
+
+    config:
+      dynamic:
+        # Set filtered_alias_mode to 'disallow' to forbid more than 2 filtered aliases per index
+        # Set filtered_alias_mode to 'warn' to allow more than 2 filtered aliases per index but warns about it (default)
+        # Set filtered_alias_mode to 'nowarn' to allow more than 2 filtered aliases per index silently
+        #filtered_alias_mode: warn
+        #do_not_fail_on_forbidden: false
+        #kibana:
+        # Kibana multitenancy
+        #multitenancy_enabled: true
+        #server_username: kibanaserver
+        #index: '.kibana'
+        http:
+          anonymous_auth_enabled: false
+          xff:
+            enabled: false
+            internalProxies: '192\.168\.0\.10|192\.168\.0\.11' # regex pattern
+            #internalProxies: '.*' # trust all internal proxies, regex pattern
+            #remoteIpHeader:  'x-forwarded-for'
+            ###### see https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html for regex help
+            ###### more information about XFF https://en.wikipedia.org/wiki/X-Forwarded-For
+            ###### and here https://tools.ietf.org/html/rfc7239
+            ###### and https://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Remote_IP_Valve
+        authc:
+          kerberos_auth_domain:
+            http_enabled: false
+            transport_enabled: false
+            order: 6
+            http_authenticator:
+              type: kerberos
+              challenge: true
+              config:
+                # If true a lot of kerberos/security related debugging output will be logged to standard out
+                krb_debug: false
+                # If true then the realm will be stripped from the user name
+                strip_realm_from_principal: true
+            authentication_backend:
+              type: noop
+          basic_internal_auth_domain:
+            description: "Authenticate via HTTP Basic against internal users database"
+            http_enabled: true
+            transport_enabled: true
+            order: 4
+            http_authenticator:
+              type: basic
+              challenge: true
+            authentication_backend:
+              type: intern
+          proxy_auth_domain:
+            description: "Authenticate via proxy"
+            http_enabled: false
+            transport_enabled: false
+            order: 3
+            http_authenticator:
+              type: proxy
+              challenge: false
+              config:
+                user_header: "x-proxy-user"
+                roles_header: "x-proxy-roles"
+            authentication_backend:
+              type: noop
+          jwt_auth_domain:
+            description: "Authenticate via Json Web Token"
+            http_enabled: false
+            transport_enabled: false
+            order: 0
+            http_authenticator:
+              type: jwt
+              challenge: false
+              config:
+                signing_key: "base64 encoded HMAC key or public RSA/ECDSA pem key"
+                jwt_header: "Authorization"
+                jwt_url_parameter: null
+                roles_key: null
+                subject_key: null
+            authentication_backend:
+              type: noop
+          clientcert_auth_domain:
+            description: "Authenticate via SSL client certificates"
+            http_enabled: false
+            transport_enabled: false
+            order: 2
+            http_authenticator:
+              type: clientcert
+              config:
+                username_attribute: cn #optional, if omitted DN becomes username
+              challenge: false
+            authentication_backend:
+              type: noop
+          ldap:
+            description: "Authenticate via LDAP or Active Directory"
+            http_enabled: false
+            transport_enabled: false
+            order: 5
+            http_authenticator:
+              type: basic
+              challenge: false
+            authentication_backend:
+              # LDAP authentication backend (authenticate users against a LDAP or Active Directory)
+              type: ldap
+              config:
+                # enable ldaps
+                enable_ssl: false
+                # enable start tls, enable_ssl should be false
+                enable_start_tls: false
+                # send client certificate
+                enable_ssl_client_auth: false
+                # verify ldap hostname
+                verify_hostnames: true
+                hosts:
+                - localhost:8389
+                bind_dn: null
+                password: null
+                userbase: 'ou=people,dc=example,dc=com'
+                # Filter to search for users (currently in the whole subtree beneath userbase)
+                # {0} is substituted with the username
+                usersearch: '(sAMAccountName={0})'
+                # Use this attribute from the user as username (if not set then DN is used)
+                username_attribute: null
+        authz:
+          roles_from_myldap:
+            description: "Authorize via LDAP or Active Directory"
+            http_enabled: false
+            transport_enabled: false
+            authorization_backend:
+              # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
+              type: ldap
+              config:
+                # enable ldaps
+                enable_ssl: false
+                # enable start tls, enable_ssl should be false
+                enable_start_tls: false
+                # send client certificate
+                enable_ssl_client_auth: false
+                # verify ldap hostname
+                verify_hostnames: true
+                hosts:
+                - localhost:8389
+                bind_dn: null
+                password: null
+                rolebase: 'ou=groups,dc=example,dc=com'
+                # Filter to search for roles (currently in the whole subtree beneath rolebase)
+                # {0} is substituted with the DN of the user
+                # {1} is substituted with the username
+                # {2} is substituted with an attribute value from user's directory entry, of the authenticated user. Use userroleattribute to specify the name of the attribute
+                rolesearch: '(member={0})'
+                # Specify the name of the attribute which value should be substituted with {2} above
+                userroleattribute: null
+                # Roles as an attribute of the user entry
+                userrolename: disabled
+                #userrolename: memberOf
+                # The attribute in a role entry containing the name of that role, Default is "name".
+                # Can also be "dn" to use the full DN as rolename.
+                rolename: cn
+                # Resolve nested roles transitive (roles which are members of other roles and so on ...)
+                resolve_nested_roles: true
+                userbase: 'ou=people,dc=example,dc=com'
+                # Filter to search for users (currently in the whole subtree beneath userbase)
+                # {0} is substituted with the username
+                usersearch: '(uid={0})'
+                # Skip users matching a user name, a wildcard or a regex pattern
+                #skip_users:
+                #  - 'cn=Michael Jackson,ou*people,o=TEST'
+                #  - '/\S*/'
+          roles_from_another_ldap:
+            description: "Authorize via another Active Directory"
+            http_enabled: false
+            transport_enabled: false
+            authorization_backend:
+              type: ldap
+              #config goes here ...
+      #    auth_failure_listeners:
+      #      ip_rate_limiting:
+      #        type: ip
+      #        allowed_tries: 10
+      #        time_window_seconds: 3600
+      #        block_expiry_seconds: 600
+      #        max_blocked_clients: 100000
+      #        max_tracked_clients: 100000
+      #      internal_authentication_backend_limiting:
+      #        type: username
+      #        authentication_backend: intern
+      #        allowed_tries: 10
+      #        time_window_seconds: 3600
+      #        block_expiry_seconds: 600
+      #        max_blocked_clients: 100000
+      #        max_tracked_clients: 100000              
+{{- end }}
+{{- if .Values.opensearch.global.securityConfig.overrides.internal_users }}
+  internal_users.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.internal_users | indent 4 }}       
+{{- else }}
+  internal_users.yml: |
+    ---
+    # This is the internal user database
+    # The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+    _meta:
+      type: "internalusers"
+      config_version: 2
+
+    # Define your internal users here
+
+    ## Demo users
+
+    admin:
+      hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+      reserved: true
+      backend_roles:
+      - "admin"
+      description: "Demo admin user"
+
+    kibanaserver:
+      hash: "$2a$12$4AcgAt3xwOWadA5s5blL6ev39OXDNhmOesEoo33eZtrq2N0YrU3H."
+      reserved: true
+      description: "Demo OpenSearch Dashboards user"
+
+    kibanaro:
+      hash: "$2a$12$JJSXNfTowz7Uu5ttXfeYpeYE0arACvcwlPBStB1F.MI7f0U9Z4DGC"
+      reserved: false
+      backend_roles:
+      - "kibanauser"
+      - "readall"
+      attributes:
+        attribute1: "value1"
+        attribute2: "value2"
+        attribute3: "value3"
+      description: "Demo OpenSearch Dashboards read only user"
+
+    logstash:
+      hash: "$2a$12$u1ShR4l4uBS3Uv59Pa2y5.1uQuZBrZtmNfqB3iM/.jL0XoV9sghS2"
+      reserved: false
+      backend_roles:
+      - "logstash"
+      description: "Demo logstash user"
+
+    readall:
+      hash: "$2a$12$ae4ycwzwvLtZxwZ82RmiEunBbIPiAmGZduBAjKN0TXdwQFtCwARz2"
+      reserved: false
+      backend_roles:
+      - "readall"
+      description: "Demo readall user"
+
+    snapshotrestore:
+      hash: "$2y$12$DpwmetHKwgYnorbgdvORCenv4NAK8cPUg8AI6pxLCuWf/ALc0.v7W"
+      reserved: false
+      backend_roles:
+      - "snapshotrestore"
+      description: "Demo snapshotrestore user"
+{{- end }}      
+{{- if .Values.opensearch.global.securityConfig.overrides.roles }}
+  roles.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.roles | indent 4 }}       
+{{- else }}
+  roles.yml: | 
+    _meta:
+      type: "roles"
+      config_version: 2
+
+    # Restrict users so they can only view visualization and dashboard on OpenSearchDashboards
+    kibana_read_only:
+      reserved: true
+
+    # The security REST API access role is used to assign specific users access to change the security settings through the REST API.
+    security_rest_api_access:
+      reserved: true
+    
+    # Allows users to view monitors, destinations and alerts
+    alerting_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/alerting/alerts/get'
+        - 'cluster:admin/opendistro/alerting/destination/get'
+        - 'cluster:admin/opendistro/alerting/monitor/get'
+        - 'cluster:admin/opendistro/alerting/monitor/search'
+
+    # Allows users to view and acknowledge alerts
+    alerting_ack_alerts:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/alerting/alerts/*'
+
+    # Allows users to use all alerting functionality
+    alerting_full_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster_monitor'
+        - 'cluster:admin/opendistro/alerting/*'
+      index_permissions:
+        - index_patterns:
+            - '*'
+          allowed_actions:
+            - 'indices_monitor'
+            - 'indices:admin/aliases/get'
+            - 'indices:admin/mappings/get'
+
+    # Allow users to read Anomaly Detection detectors and results
+    anomaly_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/ad/detector/info'
+        - 'cluster:admin/opendistro/ad/detector/search'
+        - 'cluster:admin/opendistro/ad/detectors/get'
+        - 'cluster:admin/opendistro/ad/result/search'
+        - 'cluster:admin/opendistro/ad/tasks/search'
+
+    # Allows users to use all Anomaly Detection functionality
+    anomaly_full_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster_monitor'
+        - 'cluster:admin/opendistro/ad/*'
+      index_permissions:
+        - index_patterns:
+            - '*'
+          allowed_actions:
+            - 'indices_monitor'
+            - 'indices:admin/aliases/get'
+            - 'indices:admin/mappings/get'
+
+    # Allows users to read Notebooks
+    notebooks_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/notebooks/list'
+        - 'cluster:admin/opendistro/notebooks/get'
+
+    # Allows users to all Notebooks functionality
+    notebooks_full_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/notebooks/create'
+        - 'cluster:admin/opendistro/notebooks/update'
+        - 'cluster:admin/opendistro/notebooks/delete'
+        - 'cluster:admin/opendistro/notebooks/get'
+        - 'cluster:admin/opendistro/notebooks/list'
+
+    # Allows users to read and download Reports
+    reports_instances_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/reports/instance/list'
+        - 'cluster:admin/opendistro/reports/instance/get'
+        - 'cluster:admin/opendistro/reports/menu/download'
+
+    # Allows users to read and download Reports and Report-definitions
+    reports_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/reports/definition/get'
+        - 'cluster:admin/opendistro/reports/definition/list'
+        - 'cluster:admin/opendistro/reports/instance/list'
+        - 'cluster:admin/opendistro/reports/instance/get'
+        - 'cluster:admin/opendistro/reports/menu/download'
+
+    # Allows users to all Reports functionality
+    reports_full_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/reports/definition/create'
+        - 'cluster:admin/opendistro/reports/definition/update'
+        - 'cluster:admin/opendistro/reports/definition/on_demand'
+        - 'cluster:admin/opendistro/reports/definition/delete'
+        - 'cluster:admin/opendistro/reports/definition/get'
+        - 'cluster:admin/opendistro/reports/definition/list'
+        - 'cluster:admin/opendistro/reports/instance/list'
+        - 'cluster:admin/opendistro/reports/instance/get'
+        - 'cluster:admin/opendistro/reports/menu/download'
+
+    # Allows users to use all asynchronous-search functionality
+    asynchronous_search_full_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/asynchronous_search/*'
+      index_permissions:
+        - index_patterns:
+            - '*'
+          allowed_actions:
+            - 'indices:data/read/search*'
+
+    # Allows users to read stored asynchronous-search results
+    asynchronous_search_read_access:
+      reserved: true
+      cluster_permissions:
+        - 'cluster:admin/opendistro/asynchronous_search/get'  
+{{- end }}        
+{{- if .Values.opensearch.global.securityConfig.overrides.roles_mapping }}
+  roles_mapping.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.roles_mapping | indent 4 }}       
+{{- else }}
+  roles_mapping.yml: |
+    # In this file users, backendroles and hosts can be mapped to Security roles.
+    # Permissions for OpenSearch roles are configured in roles.yml
+
+    _meta:
+      type: "rolesmapping"
+      config_version: 2
+
+    # Define your roles mapping here
+
+    ## Demo roles mapping
+
+    all_access:
+      reserved: false
+      backend_roles:
+      - "admin"
+      description: "Maps admin to all_access"
+
+    own_index:
+      reserved: false
+      users:
+      - "*"
+      description: "Allow full access to an index named like the username"
+
+    logstash:
+      reserved: false
+      backend_roles:
+      - "logstash"
+
+    kibana_user:
+      reserved: false
+      backend_roles:
+      - "kibanauser"
+      description: "Maps kibanauser to kibana_user"
+
+    readall:
+      reserved: false
+      backend_roles:
+      - "readall"
+
+    manage_snapshots:
+      reserved: false
+      backend_roles:
+      - "snapshotrestore"
+
+    kibana_server:
+      reserved: true
+      users:
+      - "kibanaserver"
+{{- end }}      
+{{- if .Values.opensearch.global.securityConfig.overrides.tenants }}
+  tenants.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.tenants | indent 4 }}       
+{{- else }}
+  tenants.yml: |
+    ---
+    _meta:
+      type: "tenants"
+      config_version: 2
+
+    # Define your tenants here
+
+    ## Demo tenants
+    admin_tenant:
+      reserved: false
+      description: "Demo tenant for admin user"
+{{- end }}      
+{{- if .Values.opensearch.global.securityConfig.overrides.whitelist }}
+  whitelist.yml: |
+{{ .Values.opensearch.global.securityConfig.overrides.whitelist | indent 4 }}       
+{{- else }}
+  whitelist.yml: |
+    ---
+    _meta:
+      type: "whitelist"
+      config_version: 2
+
+    # Description:
+    # enabled - feature flag.
+    # if enabled is false, the whitelisting feature is removed.
+    # This is like removing the check that checks if an API is whitelisted.
+    # This is equivalent to continuing with the usual access control checks, and removing all the code that implements whitelisting.
+    # if enabled is true, then all users except SuperAdmin can access only the APIs in requests
+    # SuperAdmin can access all APIs.
+    # SuperAdmin is defined by the SuperAdmin certificate, which is configured in the opensearch.yml setting: plugins.security.authcz.admin_dn:
+    # Refer to the example setting in opensearch.yml.example, and the opendistro documentation to know more about configuring SuperAdmin.
+    #
+    # requests - map of whitelisted endpoints, and the whitelisted HTTP requests for those endpoints
+
+    # Examples showing how to configure this yml file (make sure the _meta data from above is also there):
+    # Example 1:
+    # To enable whitelisting and whitelist GET /_cluster/settings
+    #
+    #config:
+    #  enabled: true
+    #  requests:
+    #    /_cluster/settings:
+    #      - GET
+    #
+    # Example 2:
+    # If you want to whitelist multiple request methods for /_cluster/settings (GET,PUT):
+    #
+    #config:
+    #  enabled: true
+    #  requests:
+    #    /_cluster/settings:
+    #      - GET
+    #      - PUT
+    #
+    # Example 3:
+    # If you want to whitelist other APIs as well, for example GET /_cat/nodes, and GET /_cat/shards:
+    #
+    #config:
+    #  enabled: true
+    #  requests:
+    #    /_cluster/settings:
+    #      - GET
+    #      - PUT
+    #    /_cat/nodes:
+    #      - GET
+    #    /_cat/shards:
+    #      - GET
+    #
+    # Example 4:
+    # If you want to disable the whitelisting feature, set enabled to false.
+    #  enabled: false
+    #  requests:
+    #    /_cluster/settings:
+    #      - GET
+    #
+    #At this point, all APIs become whitelisted because the feature to whitelist is off, so requests is irrelevant.
+
+
+    #this name must be config
+    config:
+      enabled: false
+      requests:
+        /_cluster/settings:
+          - GET
+        /_cat/nodes:
+          - GET
+{{- end }}          

--- a/Helm/opensearch/values.yaml
+++ b/Helm/opensearch/values.yaml
@@ -1,0 +1,348 @@
+opensearch:
+  # notes
+  # export JAVA_HOME=$PWD/jdk
+  # ./plugins/opensearch-security/tools/securityadmin.sh -cd ./plugins/opensearch-security/securityconfig/ -cert ./config/ssl/admin/tls.crt -key ./config/ssl/admin/tls.key -cacert ./config/ssl/admin/ca.crt -icl -arc -nhnv
+
+  global:
+    clusterName: opensearch
+
+    registry: docker.io
+
+    imagePullSecrets:
+      enabled: false
+      secretName: pull-secret
+
+    rbac: 
+      enabled: true
+      # Run the opensearch nodes as a dedicated service account
+      serviceAccount:
+        enabled: true
+
+        create: true
+        name: opensearch-service-account
+      
+        # Optional role to bind the service account to, must exist already
+        role:
+          name: opensearch-role
+
+        # Bind the role above to the service account, optional if created already
+        rolebinding:
+          create: true
+          name: opensearch-rolebinding
+  
+    ssl:      
+      # CertManager can automatically generate the certificates and renew them
+      certManager: false
+      # Helm can also generate certificates, not recommended for production
+
+      # Transport is required, if CertManager is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      transport:
+        commonName: CN=nodes
+        secretName: transport-tls
+
+      # Rest is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt        
+      rest:
+        enabled: true
+        commonName: CN=rest          
+        secretName: rest-tls
+
+      # Admin is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      admin:
+        enabled: true
+        commonName: CN=admin          
+        secretName: admin-tls  
+  
+    # Add additional configuration to the opensearch.yml
+    additionalConfig: |
+      #plugins.security.x: y
+    log4jConfig: |
+      status = error
+
+      appender.console.type = Console
+      appender.console.name = console
+      appender.console.layout.type = PatternLayout
+      appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+      rootLogger.level = info
+      rootLogger.appenderRef.console.ref = console
+
+    opensearchNotebook: |
+      opensearch.notebooks:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllNotebooks"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllNotebooks -> Admin user with "all_access" role can see all notebooks of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's notebooks
+          ## User -> notebooks are visible to only themselves
+          ## Roles -> notebooks are visible to users having any one of the role of creator
+          ## BackendRoles -> notebooks are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "notebooks_full_access", "notebooks_read_access"]
+
+    opensearchReports: |
+      opendistro.reports:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllReports"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllReports -> Admin user with "all_access" role can see all reports of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's reports
+          ## User -> reports are visible to only themselves
+          ## Roles -> reports are visible to users having any one of the role of creator
+          ## BackendRoles -> reports are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "reports_full_access", "reports_read_access", "reports_instances_read_access"]
+
+    # If defaults is true then the default opensearch config is used
+    # The secret must contain the following key pairs
+    # - action groups
+    # - config
+    # - internal users
+    # - roles secret
+    # - roles mapping
+    # - tenants
+    securityConfig:
+      secretName: opensearch-security
+
+      overrides:
+        enabled: false
+        #action_groups: |
+          #_meta:
+            #type: "actiongroups"
+            #config_version: 2  
+        #audit: |
+        #config: |
+        #internal_users: |
+        #roles: |
+        #roles_mapping: |
+        #tenants: |
+        #whitelist: |
+
+  # The hosts section supplies a daemonset that completes
+  # the privileged host OS configuration.
+  # It is highly recommended to not use this component and alter the 
+  # host OS's outside of Kubernetes. 
+  host:
+    sysctl:
+      enable: false
+
+  # Configuration settings for the master nodes, if no additional nodes are configured 
+  # remove the master flag from roles
+  master:    
+
+    # Removing the master flag will result in an all-role node
+    roles:
+      - master
+
+    # Runtime settings
+    image:
+      repository: opensearchproject/opensearch
+      tag: 1.0.0-rc1
+
+    imagePullPolicy: Never
+
+    # Replicas    
+    replicas: 1
+    updateStrategy: "RollingUpdates"
+
+    javaOpts: "-Xms1G -Xmx1G"
+
+    podDisruptionBudget:
+      enabled: true
+      # Set one or the other
+      minAvailable: 1
+      maxUnavailable: 
+
+    readinessProbe: []
+    livenessProbe: []
+    startupProbe: []
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+    podAnnotations: {}
+
+    persistence:
+      enabled: true
+      
+      accessModes:
+      - ReadWriteOnce
+      size: 1Gi
+      storageClass:
+      annotations: {}
+
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024Mi
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      privileged: false
+      allowPrivilegeEscalation: false
+
+    extraEnvs: []
+
+    extraVolumes: []
+    # - name: volume-name
+    #   emptyDir: {}
+
+    extraVolumeMonts: []
+    # - name: volume-name
+    #   mountPath: /
+    #   readOnly: true
+  nodes:    
+    # List of nodes to deploy and roles, deployments will use the name settings
+    # Available roles are
+    # - master
+    # - data
+    # - data_content
+    # - data_hot
+    # - data_warm
+    # - data_cold
+    # - data_frozen
+    # - ingest
+    # - remote_cluster_client
+    - name: data
+      # Runtime settings
+      image:
+        repository: opensearchproject/opensearch
+        tag: 1.0.0-rc1
+              
+      roles:
+        - data        
+        - remote_cluster_client
+      # Replicas    
+      replicas: 1
+      updateStrategy: "RollingUpdates"
+
+      javaOpts: "-Xms512m -Xmx512m"
+
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+
+      readinessProbe: []
+      livenessProbe: []
+      startupProbe: []
+
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      persistence:
+        enabled: true
+        
+        accessModes:
+        - ReadWriteOnce
+        size: 1Gi
+        storageClass:
+        annotations: {}
+
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 500m
+          memory: 1024Mi
+
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        privileged: false        
+
+      extraEnvs: []
+
+      #extraVolumes: []
+      # - name: volume-name
+         #emptyDir: {}
+
+      #extraVolumeMounts: []
+      # - name: volume-name
+      #   mountPath: /
+      #   readOnly: true
+
+    - name: ingest
+      # Runtime settings
+      image:
+        repository: opensearchproject/opensearch
+        tag: 1.0.0-rc1
+                
+      roles:
+        - ingest
+      # Replicas    
+      replicas: 1
+      updateStrategy: "RollingUpdates"
+
+      javaOpts: "-Xms512m -Xmx512m"
+
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+
+      readinessProbe: []
+      livenessProbe: []
+      startupProbe: []
+
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      persistence:
+        enabled: false
+        
+        accessModes:
+        - ReadWriteOnce
+        size: 8Gi
+        storageClass:
+        annotations: {}
+
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 500m
+          memory: 1024Mi
+
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        privileged: false        
+
+      extraEnvs: []      

--- a/Helm/values.distributed.yaml
+++ b/Helm/values.distributed.yaml
@@ -1,0 +1,400 @@
+opensearch:
+  # notes
+  # export JAVA_HOME=$PWD/jdk
+  # ./plugins/opensearch-security/tools/securityadmin.sh -cd ./plugins/opensearch-security/securityconfig/ -cert ./config/ssl/admin/tls.crt -key ./config/ssl/admin/tls.key -cacert ./config/ssl/admin/ca.crt -icl -arc -nhnv
+
+  global:
+    clusterName: opensearch
+
+    registry: docker.io
+
+    imagePullSecrets:
+      enabled: false
+      secretName: pull-secret
+
+    rbac: 
+      enabled: true
+      # Run the opensearch nodes as a dedicated service account
+      serviceAccount:
+        enabled: true
+
+        create: true
+        name: opensearch-service-account
+      
+        # Optional role to bind the service account to, must exist already
+        role:
+          name: opensearch-role
+
+        # Bind the role above to the service account, optional if created already
+        rolebinding:
+          create: true
+          name: opensearch-rolebinding
+  
+    ssl:      
+      # CertManager can automatically generate the certificates and renew them
+      certManager: false
+      # Helm can also generate certificates, not recommended for production
+
+      # Transport is required, if CertManager is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      transport:
+        commonName: CN=nodes
+        secretName: transport-tls
+
+      # Rest is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt        
+      rest:
+        enabled: true
+        commonName: CN=rest          
+        secretName: rest-tls
+
+      # Admin is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      admin:
+        enabled: true
+        commonName: CN=admin          
+        secretName: admin-tls  
+  
+    # Add additional configuration to the opensearch.yml
+    additionalConfig: |
+      #plugins.security.x: y
+    log4jConfig: |
+      status = error
+
+      appender.console.type = Console
+      appender.console.name = console
+      appender.console.layout.type = PatternLayout
+      appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+      rootLogger.level = info
+      rootLogger.appenderRef.console.ref = console
+
+    opensearchNotebook: |
+      opensearch.notebooks:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllNotebooks"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllNotebooks -> Admin user with "all_access" role can see all notebooks of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's notebooks
+          ## User -> notebooks are visible to only themselves
+          ## Roles -> notebooks are visible to users having any one of the role of creator
+          ## BackendRoles -> notebooks are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "notebooks_full_access", "notebooks_read_access"]
+
+    opensearchReports: |
+      opendistro.reports:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllReports"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllReports -> Admin user with "all_access" role can see all reports of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's reports
+          ## User -> reports are visible to only themselves
+          ## Roles -> reports are visible to users having any one of the role of creator
+          ## BackendRoles -> reports are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "reports_full_access", "reports_read_access", "reports_instances_read_access"]
+
+    # If defaults is true then the default opensearch config is used
+    # The secret must contain the following key pairs
+    # - action groups
+    # - config
+    # - internal users
+    # - roles secret
+    # - roles mapping
+    # - tenants
+    securityConfig:
+      secretName: opensearch-security
+
+      overrides:
+        enabled: false
+        #action_groups: |
+          #_meta:
+            #type: "actiongroups"
+            #config_version: 2  
+        #audit: |
+        #config: |
+        #internal_users: |
+        #roles: |
+        #roles_mapping: |
+        #tenants: |
+        #whitelist: |
+
+  # The hosts section supplies a daemonset that completes
+  # the privileged host OS configuration.
+  # It is highly recommended to not use this component and alter the 
+  # host OS's outside of Kubernetes. 
+  host:
+    sysctl:
+      enable: false
+
+  # Configuration settings for the master nodes, if no additional nodes are configured 
+  # remove the master flag from roles
+  master:    
+
+    # Removing the master flag will result in an all-role node
+    roles:
+      - master
+
+    # Runtime settings
+    image:
+      repository: opensearchproject/opensearch
+      tag: 1.0.0-rc1
+
+    imagePullPolicy: Never
+
+    # Replicas    
+    replicas: 1
+    updateStrategy: "RollingUpdates"
+
+    javaOpts: "-Xms1G -Xmx1G"
+
+    podDisruptionBudget:
+      enabled: true
+      # Set one or the other
+      minAvailable: 1
+      maxUnavailable: 
+
+    readinessProbe: []
+    livenessProbe: []
+    startupProbe: []
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+    podAnnotations: {}
+
+    persistence:
+      enabled: true
+      
+      accessModes:
+      - ReadWriteOnce
+      size: 1Gi
+      storageClass:
+      annotations: {}
+
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024Mi
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      privileged: false
+      allowPrivilegeEscalation: false
+
+    extraEnvs: []
+
+    extraVolumes: []
+    # - name: volume-name
+    #   emptyDir: {}
+
+    extraVolumeMonts: []
+    # - name: volume-name
+    #   mountPath: /
+    #   readOnly: true
+  nodes:    
+    # List of nodes to deploy and roles, deployments will use the name settings
+    # Available roles are
+    # - master
+    # - data
+    # - data_content
+    # - data_hot
+    # - data_warm
+    # - data_cold
+    # - data_frozen
+    # - ingest
+    # - remote_cluster_client
+    - name: data
+      # Runtime settings
+      image:
+        repository: opensearchproject/opensearch
+        tag: 1.0.0-rc1
+              
+      roles:
+        - data        
+      # Replicas    
+      replicas: 1
+      updateStrategy: "RollingUpdates"
+
+      javaOpts: "-Xms512m -Xmx512m"
+
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+
+      readinessProbe: []
+      livenessProbe: []
+      startupProbe: []
+
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      persistence:
+        enabled: true
+        
+        accessModes:
+        - ReadWriteOnce
+        size: 1Gi
+        storageClass:
+        annotations: {}
+
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 500m
+          memory: 1024Mi
+
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        privileged: false        
+
+      extraEnvs: []
+
+      #extraVolumes: []
+      # - name: volume-name
+         #emptyDir: {}
+
+      #extraVolumeMounts: []
+      # - name: volume-name
+      #   mountPath: /
+      #   readOnly: true
+
+    - name: ingest
+      # Runtime settings
+      image:
+        repository: opensearchproject/opensearch
+        tag: 1.0.0-rc1
+                
+      roles:
+        - ingest
+      # Replicas    
+      replicas: 1
+      updateStrategy: "RollingUpdates"
+
+      javaOpts: "-Xms512m -Xmx512m"
+
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+
+      readinessProbe: []
+      livenessProbe: []
+      startupProbe: []
+
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      persistence:
+        enabled: false
+        
+        accessModes:
+        - ReadWriteOnce
+        size: 8Gi
+        storageClass:
+        annotations: {}
+
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 500m
+          memory: 1024Mi
+
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        privileged: false        
+
+      extraEnvs: []      
+
+    - name: remote_cluster_client
+      # Runtime settings
+      image:
+        repository: opensearchproject/opensearch
+        tag: 1.0.0-rc1
+                
+      roles:
+        - remote_cluster_client
+      # Replicas    
+      replicas: 1
+      updateStrategy: "RollingUpdates"
+
+      javaOpts: "-Xms512m -Xmx512m"
+
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+
+      readinessProbe: []
+      livenessProbe: []
+      startupProbe: []
+
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      persistence:
+        enabled: false
+        
+        accessModes:
+        - ReadWriteOnce
+        size: 8Gi
+        storageClass:
+        annotations: {}
+
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 500m
+          memory: 1024Mi
+
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        privileged: false        
+
+      extraEnvs: []          

--- a/Helm/values.singleNode.yaml
+++ b/Helm/values.singleNode.yaml
@@ -1,0 +1,294 @@
+opensearch:
+  # notes
+  # export JAVA_HOME=$PWD/jdk
+  # ./plugins/opensearch-security/tools/securityadmin.sh -cd ./plugins/opensearch-security/securityconfig/ -cert ./config/ssl/admin/tls.crt -key ./config/ssl/admin/tls.key -cacert ./config/ssl/admin/ca.crt -icl -arc -nhnv
+
+  global:
+    clusterName: opensearch
+
+    registry: docker.io
+
+    imagePullSecrets:
+      enabled: false
+      secretName: pull-secret
+
+    rbac: 
+      enabled: true
+      # Run the opensearch nodes as a dedicated service account
+      serviceAccount:
+        enabled: true
+
+        create: true
+        name: opensearch-service-account
+      
+        # Optional role to bind the service account to, must exist already
+        role:
+          name: opensearch-role
+
+        # Bind the role above to the service account, optional if created already
+        rolebinding:
+          create: true
+          name: opensearch-rolebinding
+  
+    ssl:      
+      # CertManager can automatically generate the certificates and renew them
+      certManager: false
+      # Helm can also generate certificates, not recommended for production
+
+      # Transport is required, if CertManager is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      transport:
+        commonName: CN=nodes
+        secretName: transport-tls
+
+      # Rest is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt        
+      rest:
+        enabled: true
+        commonName: CN=rest          
+        secretName: rest-tls
+
+      # Admin is optional, if CertManager and Helm is disabled then provide a secret with
+      # tls.crt, tls.key and ca.crt
+      admin:
+        enabled: true
+        commonName: CN=admin          
+        secretName: admin-tls  
+  
+    # Add additional configuration to the opensearch.yml
+    additionalConfig: |
+      #plugins.security.x: y
+    log4jConfig: |
+      status = error
+
+      appender.console.type = Console
+      appender.console.name = console
+      appender.console.layout.type = PatternLayout
+      appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+      rootLogger.level = info
+      rootLogger.appenderRef.console.ref = console
+
+    opensearchNotebook: |
+      opensearch.notebooks:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllNotebooks"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllNotebooks -> Admin user with "all_access" role can see all notebooks of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's notebooks
+          ## User -> notebooks are visible to only themselves
+          ## Roles -> notebooks are visible to users having any one of the role of creator
+          ## BackendRoles -> notebooks are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "notebooks_full_access", "notebooks_read_access"]
+
+    opensearchReports: |
+      opendistro.reports:
+        general:
+          operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
+          defaultItemsQueryCount: 100 # default number of items to query
+        polling:
+          jobLockDurationSeconds: 300 # 5 Minutes, Minimum 10 seconds
+          minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
+          maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
+          maxLockRetries: 1 # Max number of retries to retry locking
+        access:
+          adminAccess: "AllReports"
+          # adminAccess values:
+          ## Standard -> Admin user access follows standard user
+          ## AllReports -> Admin user with "all_access" role can see all reports of all users.
+          filterBy: "NoFilter" # Applied when tenant != __user__
+          # filterBy values:
+          ## NoFilter -> everyone see each other's reports
+          ## User -> reports are visible to only themselves
+          ## Roles -> reports are visible to users having any one of the role of creator
+          ## BackendRoles -> reports are visible to users having any one of the backend role of creator
+          ignoreRoles: ["own_index", "kibana_user", "reports_full_access", "reports_read_access", "reports_instances_read_access"]
+
+    # If defaults is true then the default opensearch config is used
+    # The secret must contain the following key pairs
+    # - action groups
+    # - config
+    # - internal users
+    # - roles secret
+    # - roles mapping
+    # - tenants
+    securityConfig:
+      secretName: opensearch-security
+
+      overrides:
+        enabled: false
+        #action_groups: |
+          #_meta:
+            #type: "actiongroups"
+            #config_version: 2  
+        #audit: |
+        #config: |
+        #internal_users: |
+        #roles: |
+        #roles_mapping: |
+        #tenants: |
+        #whitelist: |
+
+  # The hosts section supplies a daemonset that completes
+  # the privileged host OS configuration.
+  # It is highly recommended to not use this component and alter the 
+  # host OS's outside of Kubernetes. 
+  host:
+    sysctl:
+      enable: false
+
+  # Configuration settings for the master nodes, if no additional nodes are configured 
+  # remove the master flag from roles
+  master:    
+
+    # Removing the master flag will result in an all-role node
+    roles:
+      #- master
+
+    # Runtime settings
+    image:
+      repository: opensearchproject/opensearch
+      tag: 1.0.0-rc1
+
+    imagePullPolicy: Never
+
+    # Replicas    
+    replicas: 1
+    updateStrategy: "RollingUpdates"
+
+    javaOpts: "-Xms1G -Xmx1G"
+
+    podDisruptionBudget:
+      enabled: true
+      # Set one or the other
+      minAvailable: 1
+      maxUnavailable: 
+
+    readinessProbe: []
+    livenessProbe: []
+    startupProbe: []
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+    podAnnotations: {}
+
+    persistence:
+      enabled: true
+      
+      accessModes:
+      - ReadWriteOnce
+      size: 1Gi
+      storageClass:
+      annotations: {}
+
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024Mi
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      privileged: false
+      allowPrivilegeEscalation: false
+
+    extraEnvs: []
+
+    extraVolumes: []
+    # - name: volume-name
+    #   emptyDir: {}
+
+    extraVolumeMonts: []
+    # - name: volume-name
+    #   mountPath: /
+    #   readOnly: true
+  nodes:    
+    # List of nodes to deploy and roles, deployments will use the name settings
+    # Available roles are
+    # - master
+    # - data
+    # - data_content
+    # - data_hot
+    # - data_warm
+    # - data_cold
+    # - data_frozen
+    # - ingest
+    # - remote_cluster_client
+    #- name: data
+      # Runtime settings
+      #image:
+        #repository: opensearchproject/opensearch
+        #tag: 1.0.0-rc1
+              
+      #roles:
+        #- data                
+      # Replicas    
+      #replicas: 1
+      #updateStrategy: "RollingUpdates"
+
+      #javaOpts: "-Xms512m -Xmx512m"
+
+      #podDisruptionBudget:
+        #enabled: true
+        #minAvailable: 1
+
+      #readinessProbe: []
+      #livenessProbe: []
+      #startupProbe: []
+
+      #nodeSelector: {}
+      #tolerations: []
+      #affinity: {}
+
+      #podAnnotations: {}
+
+      #persistence:
+        #enabled: true
+        
+        #accessModes:
+        #- ReadWriteOnce
+        #size: 1Gi
+        #storageClass:
+        #annotations: {}
+
+      #resources:
+        #requests:
+          #cpu: 500m
+          #memory: 1024Mi
+        #limits:
+          #cpu: 500m
+          #memory: 1024Mi
+
+      #securityContext:
+        #runAsUser: 1000
+        #runAsGroup: 1000
+        #fsGroup: 1000
+        #privileged: false        
+
+      #extraEnvs: []
+
+      #extraVolumes: []
+      # - name: volume-name
+         #emptyDir: {}
+
+      #extraVolumeMounts: []
+      # - name: volume-name
+      #   mountPath: /
+      #   readOnly: true


### PR DESCRIPTION
### Description
OpenSearch Helm chart variant, this chart is a redux of an OpenDistro chart I wrote for work, if there is interest in this type of deployment I will keep working on it as an opensource project! 

The chart is still very much an alpha release, the core concept of node based objects functions though. 

This chart treats OpenSearch nodes as objects, administrators are able to define the node type (warm, cold, ingest, master etc) and pod parameters, the configuration is then deployed as a scalable Statefulset.

There is no Dashboards included in this chart, that will be a separate component.

Please see the Helm [README](https://github.com/iron-rain/opensearch-devops/blob/main/Helm/README.md) for a the current and future features I have planned. 
 
### Issues Resolved
- 2
- 5
- Scalability and granularity in cluster definition, this is not an OpenSearch specific issue, we found with the OpenDistro or Elasticsearch charts that they are mainly geared towards the Master, Data, Client set up, this chart allows multiple variants of each type to be deployed. 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
