### PR TITLE
Give networkpolicy objects a unique name

### DIFF
--- a/Helm/opensearch/templates/networkpolicy.yaml
+++ b/Helm/opensearch/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   creationTimestamp: null
-  name: opensearch-net
+  name: {{ template "opensearch.uname" . }}-opensearch-net
 spec:
   ingress:
     - from:


### PR DESCRIPTION


### Description
This fixes the problem of installing this chart multiple times in the
same namespace and having the network policy name conflict.
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
