### PR TITLE
Use the stable chart appVersion as image tag by default

### DIFF
--- a/Helm/opensearch/templates/statefulset.yaml
+++ b/Helm/opensearch/templates/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
 {{ if .Values.keystore }}
       - name: keystore
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
         - sh
@@ -217,7 +217,7 @@ spec:
       - name: "{{ template "opensearch.name" . }}"
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         ports:
         - name: http
@@ -336,7 +336,7 @@ spec:
       {{- if eq .Values.roles.master "true" }}
       # This sidecar will prevent slow master re-election
       - name: opensearch-master-graceful-termination-handler
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
         - "sh"

--- a/Helm/opensearch/values.yaml
+++ b/Helm/opensearch/values.yaml
@@ -96,7 +96,8 @@ hostAliases: []
 #  - "bar.local"
 
 image: "opensearchproject/opensearch"
-imageTag: "latest"
+# override image tag, which is .Chart.AppVersion by default
+imageTag: ""
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}


### PR DESCRIPTION
### Description
Using :latest by default is going to lead to clusters with version skew
as pods schedule onto new nodes. So use a stable tag instead.
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
