### PR TITLE
fix sts securityConfig secret volumes

### DIFF
--- a/Helm/opensearch/Chart.yaml
+++ b/Helm/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Helm/opensearch/templates/statefulset.yaml
+++ b/Helm/opensearch/templates/statefulset.yaml
@@ -132,6 +132,41 @@ spec:
             defaultMode: {{ .defaultMode }}
             {{- end }}
         {{- end }}
+        {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data }}
+        - name: security-config
+          secret:
+            secretName: {{ .Values.securityConfig.config.securityConfigSecret }}
+        {{- end }}
+        {{- if .Values.securityConfig.actionGroupsSecret }}
+        - name: action-groups
+          secret:
+            secretName: {{ .Values.securityConfig.actionGroupsSecret }}
+        {{- end }}
+        {{- if .Values.securityConfig.configSecret }}
+        - name: security-config
+          secret:
+            secretName: {{ .Values.securityConfig.configSecret }}
+        {{- end }}
+        {{- if .Values.securityConfig.internalUsersSecret }}
+        - name: internal-users-config
+          secret:
+            secretName: {{ .Values.securityConfig.internalUsersSecret }}
+        {{- end }}
+        {{- if .Values.securityConfig.rolesSecret }}
+        - name: roles
+          secret:
+            secretName: {{ .Values.securityConfig.rolesSecret }}
+        {{- end }}
+        {{- if .Values.securityConfig.rolesMappingSecret }}
+        - name: role-mapping
+          secret:
+            secretName: {{ .Values.securityConfig.rolesMappingSecret }}
+        {{- end -}}
+        {{- if .Values.securityConfig.tenantsSecret }}
+        - name: tenants
+          secret:
+            secretName: {{ .Values.securityConfig.tenantsSecret }}
+        {{- end }}
         {{- if .Values.config }}
         - name: config
           configMap:
@@ -144,17 +179,17 @@ spec:
         - name: keystore-{{ .secretName }}
           secret: {{ toYaml . | nindent 12 }}
         {{- end }}
-{{ end }}
-      {{- if .Values.extraVolumes }}
-      # Currently some extra blocks accept strings
-      # to continue with backwards compatibility this is being kept
-      # whilst also allowing for yaml to be specified too.
-      {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
+{{- end }}
+        {{- if .Values.extraVolumes }}
+        # Currently some extra blocks accept strings
+        # to continue with backwards compatibility this is being kept
+        # whilst also allowing for yaml to be specified too.
+        {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
 {{ tpl .Values.extraVolumes . | indent 8 }}
-      {{- else }}
+        {{- else }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
-      {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -257,42 +292,6 @@ spec:
           - name: node.{{ $role }}
             value: "{{ $enabled }}"
           {{- end }}
-          {{- if .Values.securityConfig.enabled }}
-          {{- if .Values.securityConfig.actionGroupsSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/action_groups.yml
-              name: action-groups
-              subPath: action_groups.yml
-          {{- end }}
-          {{- if .Values.securityConfig.configSecret }}
-            - mountPath: {{ .Values.securityConfig.path }}/config.yml
-            name: security-config
-            subPath: config.yml
-          {{- end }}
-          {{- if .Values.securityConfig.internalUsersSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/internal_users.yml
-            name: internal-users-config
-            subPath: internal_users.yml
-          {{- end }}
-          {{- if .Values.securityConfig.rolesSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/roles.yml
-            name: roles
-            subPath: roles.yml
-          {{- end }}
-          {{- if .Values.securityConfig.rolesMappingSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/roles_mapping.yml
-            name: role-mapping
-            subPath: roles_mapping.yml
-          {{- end }}
-          {{- if .Values.securityConfig.tenantsSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/tenants.yml
-            name: tenants
-            subPath: tenants.yml
-          {{- end }}
-          {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data  }}
-          - mountPath: {{ .Values.securityConfig.path }}
-            name: security-config
-        {{- end }}
-        {{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}
 {{- end }}
@@ -322,6 +321,42 @@ spec:
             mountPath: /usr/share/opensearch/config/{{ $path }}
             subPath: {{ $path }}
           {{- end -}}
+          {{- if .Values.securityConfig.enabled }}
+          {{- if .Values.securityConfig.actionGroupsSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/action_groups.yml
+            name: action-groups
+            subPath: action_groups.yml
+          {{- end }}
+          {{- if .Values.securityConfig.configSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/config.yml
+            name: security-config
+            subPath: config.yml
+          {{- end }}
+          {{- if .Values.securityConfig.internalUsersSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/internal_users.yml
+            name: internal-users-config
+            subPath: internal_users.yml
+          {{- end }}
+          {{- if .Values.securityConfig.rolesSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/roles.yml
+            name: roles
+            subPath: roles.yml
+          {{- end }}
+          {{- if .Values.securityConfig.rolesMappingSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/roles_mapping.yml
+            name: role-mapping
+            subPath: roles_mapping.yml
+          {{- end }}
+          {{- if .Values.securityConfig.tenantsSecret }}
+          - mountPath: {{ .Values.securityConfig.path }}/tenants.yml
+            name: tenants
+            subPath: tenants.yml
+          {{- end }}
+          {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data  }}
+          - mountPath: {{ .Values.securityConfig.path }}
+            name: security-config
+          {{- end }}
+          {{- end }}
         {{- if .Values.extraVolumeMounts }}
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept


### PR DESCRIPTION
### Description
add `volumes` part of Pod spec in `statefulset`
for securityConfig secrets which are defined in `.Values.securityConfig.*Secret`.
 
### Issues Resolved
fixed #26 
 
### Check List
- [X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
