### PR TITLE
Fixing config path in opensearch-dashboards

### DIFF
--- a/Helm/opensearch-dashboards/templates/deployment.yaml
+++ b/Helm/opensearch-dashboards/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
           {{- end }}
           {{- range $path, $config := .Values.config }}
           - name: config
-            mountPath: /usr/share/dashboards/config/{{ $path }}
+            mountPath: /usr/share/opensearch-dashboards/config/{{ $path }}
             subPath: {{ $path }}
           {{- end }}
       {{- if .Values.extraContainers }}

--- a/Helm/opensearch-dashboards/values.yaml
+++ b/Helm/opensearch-dashboards/values.yaml
@@ -67,9 +67,9 @@ config:
       ## Dashboards TLS Config
       ssl:
         enabled: false
-        key: /usr/share/dashboards/certs/dashboards-key.pem
-        certificate: /usr/share/dashboards/certs/dashboards-crt.pem
-    opensearch.ssl.certificateAuthorities: /usr/share/dashboards/certs/dashboards-root-ca.pem
+        key: /usr/share/opensearch-dashboards/certs/dashboards-key.pem
+        certificate: /usr/share/opensearch-dashboards/certs/dashboards-crt.pem
+    opensearch.ssl.certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
 
 priorityClassName: ""
 

--- a/Helm/opensearch-dashboards/values.yaml
+++ b/Helm/opensearch-dashboards/values.yaml
@@ -25,7 +25,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-
 rbac:
   create: true
 
@@ -59,22 +58,20 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-
 config:
-  dashboards.yml:
+  opensearch_dashboards.yml:
     server:
-        name: dashboards
-        host: 0.0.0.0
+      name: dashboards
+      host: 0.0.0.0
 
-    ## Dashboards TLS Config
-        ssl:
-          enabled: false
-          key: /usr/share/dashboards/certs/dashboards-key.pem
-          certificate: /usr/share/dashboards/certs/dashboards-crt.pem
+      ## Dashboards TLS Config
+      ssl:
+        enabled: false
+        key: /usr/share/dashboards/certs/dashboards-key.pem
+        certificate: /usr/share/dashboards/certs/dashboards-crt.pem
     opensearch.ssl.certificateAuthorities: /usr/share/dashboards/certs/dashboards-root-ca.pem
 
 priorityClassName: ""
-
 
 opensearchAccount:
   secret: ""
@@ -104,21 +101,21 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-      - path: /
-        backend:
-          serviceName: chart-example.local
-          servicePort: 80
+        - path: /
+          backend:
+            serviceName: chart-example.local
+            servicePort: 80
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
 
 resources:
   requests:


### PR DESCRIPTION
The manifests rendered by the Helm chart place the user provided config
into the incorrect directory. This simply updates that location to the
correct path and updates the values.yaml file to use the correct default
config file so that the user provided setting override the defaults.

Signed-off-by: Harrison Goscenski <harrison.goscenski@imanage.com>

### Description
Resolves issue #37 

### Issues Resolved
#37 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
