### PR TITLE
support for current ingress apiVersion

### DIFF
--- a/Helm/opensearch-dashboards/templates/ingress.yaml
+++ b/Helm/opensearch-dashboards/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "opensearch-dashboards.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -27,6 +29,22 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+  {{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- else -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -38,4 +56,5 @@ spec:
               servicePort: {{ $svcPort }}
           {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}


### PR DESCRIPTION
### Description
The ingress `apiVersion: networking.k8s.io/v1` is available in kubernetes 1.19 and is the only valid version in kubernetes 1.22+.

 You may also want to do a similar patch for `Helm/opensearch/templates/ingress.yaml`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
