### PR TITLE
Fix helm chart can not be deployed without ssl

### DIFF
--- a/Helm/opensearch-dashboards/values.yaml
+++ b/Helm/opensearch-dashboards/values.yaml
@@ -66,14 +66,17 @@ config:
 
       ssl:
         enabled: false
-    opensearch.ssl.verificationMode: none
-
       ## Dashboards TLS Config (if providing TLS Certs uncomment below, and ensure files are present in container)
-    #   ssl:
-    #     enabled: true
-    #     key: /usr/share/opensearch-dashboards/certs/dashboards-key.pem
-    #     certificate: /usr/share/opensearch-dashboards/certs/dashboards-crt.pem
-    # opensearch.ssl.certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
+      # enabled: true
+      # key: /usr/share/opensearch-dashboards/certs/dashboards-key.pem
+      # certificate: /usr/share/opensearch-dashboards/certs/dashboards-crt.pem
+
+    # determines how dashboards will verify certificates (needs to be none for default opensearch certificates to work)
+    opensearch:
+      ssl:
+        verificationMode: none
+        # if utilizing custom CA certs for connection to opensearch, provide the CA here
+        # certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
 
 priorityClassName: ""
 

--- a/Helm/opensearch-dashboards/values.yaml
+++ b/Helm/opensearch-dashboards/values.yaml
@@ -64,12 +64,16 @@ config:
       name: dashboards
       host: 0.0.0.0
 
-      ## Dashboards TLS Config
       ssl:
         enabled: false
-        key: /usr/share/opensearch-dashboards/certs/dashboards-key.pem
-        certificate: /usr/share/opensearch-dashboards/certs/dashboards-crt.pem
-    opensearch.ssl.certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
+    opensearch.ssl.verificationMode: none
+
+      ## Dashboards TLS Config (if providing TLS Certs uncomment below, and ensure files are present in container)
+    #   ssl:
+    #     enabled: true
+    #     key: /usr/share/opensearch-dashboards/certs/dashboards-key.pem
+    #     certificate: /usr/share/opensearch-dashboards/certs/dashboards-crt.pem
+    # opensearch.ssl.certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
 
 priorityClassName: ""
 


### PR DESCRIPTION
After switching the name of the config file, and removing the shadowing
between the default (from the docker container opensearch-dashbaords.yaml) and the default from the helm chart (dashboards.yaml) there is an issue with the certs that are attempting to be used.

In order for this to work with the defaults, disabled TLS verification
will be needed, and then disabling TLS to remain in line with the
defaults.

I added a commented out section showing what could potentially be used
as TLS config if the user chooses to enable it.

Signed-off-by: Harrison Goscenski <harrison.goscenski@imanage.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
#55
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
