### PR TITLE
fix typo in securityconfig.yml labels

### DIFF
--- a/Helm/opensearch/templates/securityconfig.yaml
+++ b/Helm/opensearch/templates/securityconfig.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ .Values.securityConfig.config.securityConfigSecret }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: { { .Chart.Name } }
-    release: { { .Release.Name } }
-    heritage: { { .Release.Service } }
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 type: Opaque
 data:
   {{- range $key, $val := .Values.securityConfig.config.data }}


### PR DESCRIPTION
this securityconfig can not be used if we enable securityConfig

### Description

bug issue: https://github.com/opensearch-project/opensearch-devops/pull/62

security config labels using wrongly expression.
`{ { .Chart.name } } ` -> `{{ .Chart.name }}` 
 
### Issues Resolved
fix the typo.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
