### PR TITLE
Add commons Stack with DNS and certificate

### DIFF
--- a/.github/workflows/deploy-nightly-playground.yml
+++ b/.github/workflows/deploy-nightly-playground.yml
@@ -85,7 +85,7 @@ jobs:
     needs: 
       - set-os-osd-urls
       - validate-and-deploy
-    uses: gaiksaya/opensearch-devops/.github/workflows/index-data.yml@add-GHA
+    uses: opensearch-project/opensearch-devops/.github/workflows/index-data.yml@main
     with:
       endpoint: ${{ needs.validate-and-deploy.outputs.ENDPOINT }}
       opensearch-manifest-url: ${{ needs.set-os-osd-urls.outputs.OPENSEARCH_DIST_MANIFEST_URL }}

--- a/.github/workflows/index-data.yml
+++ b/.github/workflows/index-data.yml
@@ -33,6 +33,6 @@ jobs:
           yq -o=json '.' opensearch.yml > opensearch.json
           yq -o=json '.' opensearch-dashboards.yml > dashboards.json
 
-          curl -X POST "https://${{inputs.endpoint}}/opensearch/_doc/1" -H "Content-Type: application/json" -d @opensearch.json -u ${{ secrets.opensearch-user }}:${{ secrets.opensearch-password }} --insecure
+          curl -X POST "https://${{inputs.endpoint}}:8443/opensearch/_doc/1" -H "Content-Type: application/json" -d @opensearch.json -u ${{ secrets.opensearch-user }}:${{ secrets.opensearch-password }} --insecure
 
-          curl -X POST "https://${{inputs.endpoint}}/opensearch-dashboards/_doc/1" -H "Content-Type: application/json" -d @dashboards.json -u ${{ secrets.opensearch-user }}:${{ secrets.opensearch-password }} --insecure
+          curl -X POST "https://${{inputs.endpoint}}:8443/opensearch-dashboards/_doc/1" -H "Content-Type: application/json" -d @dashboards.json -u ${{ secrets.opensearch-user }}:${{ secrets.opensearch-password }} --insecure

--- a/nightly-playground/lib/common-tools-stack.ts
+++ b/nightly-playground/lib/common-tools-stack.ts
@@ -1,0 +1,30 @@
+/* Copyright OpenSearch Contributors
+SPDX-License-Identifier: Apache-2.0
+
+The OpenSearch Contributors require contributions made to
+this file be licensed under the Apache-2.0 license or a
+compatible open source license. */
+
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
+import { HostedZone } from 'aws-cdk-lib/aws-route53';
+import { Construct } from 'constructs';
+
+export class CommonToolsStack extends Stack {
+    readonly certificateArn: string
+
+    constructor(scope: Construct, id: string, props: StackProps) {
+      super(scope, id, props);
+      const zone = 'playground.nightly.opensearch.org';
+
+      const route53HostedZone = new HostedZone(this, 'nigghhtlyHostedZone', {
+        zoneName: zone,
+      });
+
+      const certificate = new Certificate(this, 'cert', {
+        domainName: zone,
+        validation: CertificateValidation.fromDns(route53HostedZone),
+      });
+      this.certificateArn = certificate.certificateArn;
+    }
+}

--- a/nightly-playground/package-lock.json
+++ b/nightly-playground/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nightly-playground",
       "version": "0.1.0",
       "dependencies": {
-        "@opensearch-project/opensearch-cluster-cdk": "1.1.0",
+        "@opensearch-project/opensearch-cluster-cdk": "1.2.0",
         "@types/babel__traverse": "^7.18.2",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -1323,9 +1323,9 @@
       }
     },
     "node_modules/@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.1.0.tgz",
-      "integrity": "sha512-24YkGmo005ALFZ6hRBCLJOiVLzmpMclsfI9iyz3gYtbraSbFKkh+EQfEuO4L+WLxvg7gw826Cy/uu2ZAGDs23w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.0.tgz",
+      "integrity": "sha512-zXJc/CaeBeI42YGCI3iimUjm0OY7rDRHZaACz4akpqWSm7X+Wp7FMkp0GTsOZo9rRa59zqirplekfrenAF3M+A==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -7889,9 +7889,9 @@
       }
     },
     "@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.1.0.tgz",
-      "integrity": "sha512-24YkGmo005ALFZ6hRBCLJOiVLzmpMclsfI9iyz3gYtbraSbFKkh+EQfEuO4L+WLxvg7gw826Cy/uu2ZAGDs23w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.0.tgz",
+      "integrity": "sha512-zXJc/CaeBeI42YGCI3iimUjm0OY7rDRHZaACz4akpqWSm7X+Wp7FMkp0GTsOZo9rRa59zqirplekfrenAF3M+A==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/nightly-playground/package.json
+++ b/nightly-playground/package.json
@@ -22,7 +22,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@opensearch-project/opensearch-cluster-cdk": "1.1.0",
+    "@opensearch-project/opensearch-cluster-cdk": "1.2.0",
     "@types/babel__traverse": "^7.18.2",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",


### PR DESCRIPTION
### Description
This PR includes below changes:
1. Bumps opensearch-cluster-cdk version to 1.2.0
2. Adds commons stack that is responsible for adding route53 and certificate 
3. Adds tests to test above resources
4. Changes opensearch and opensearch Dashboards port mapping on load balancer

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
