### PR TITLE
Add dashboards config for external cert

### DIFF
--- a/nightly-playground/lib/nightly-playground-stack.ts
+++ b/nightly-playground/lib/nightly-playground-stack.ts
@@ -32,7 +32,8 @@ export class NightlyPlaygroundStack {
       throw new Error('dashboardPassword parameter cannot be empty! Please provide the OpenSearch-Dashboards customized password for kibanauser');
     }
 
-    const additionalOsdConfigString = `{"opensearch_security.auth.anonymous_auth_enabled": "true", "opensearch.password": "${dashboardPassword}"}`;
+    const additionalOsdConfigString = `{"opensearch_security.auth.anonymous_auth_enabled": "true", "opensearch.password": "${dashboardPassword}", `
+    + '"opensearch_security.cookie.secure": "true", "opensearch_security.cookie.isSameSite": "None"}';
 
     const securtityConfig = '{ "resources/security-config/config.yml" : "opensearch/config/opensearch-security/config.yml", '
     + '"resources/security-config/roles_mapping.yml" : "opensearch/config/opensearch-security/roles_mapping.yml", '

--- a/nightly-playground/package-lock.json
+++ b/nightly-playground/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nightly-playground",
       "version": "0.1.0",
       "dependencies": {
-        "@opensearch-project/opensearch-cluster-cdk": "1.2.1",
+        "@opensearch-project/opensearch-cluster-cdk": "1.2.2",
         "@types/babel__traverse": "^7.18.2",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -1323,9 +1323,9 @@
       }
     },
     "node_modules/@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.1.tgz",
-      "integrity": "sha512-K8JjU5iP9dlid8ovL+R3eI18vDV/Ef4vpFTd88ZkBU7sUewmOiqnHc3mrtmbcm0eW4ZiAJ5P4tbahWltmSOEQw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.2.tgz",
+      "integrity": "sha512-zAX0VCi+2g7B6+ZxzRCT6B4o42ytkGa9qXYIh9DqCko82vLXq939DFDfRV5KufUuzZeR1Pc7z8X28FiqLCbidQ==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -7889,9 +7889,9 @@
       }
     },
     "@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.1.tgz",
-      "integrity": "sha512-K8JjU5iP9dlid8ovL+R3eI18vDV/Ef4vpFTd88ZkBU7sUewmOiqnHc3mrtmbcm0eW4ZiAJ5P4tbahWltmSOEQw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.2.2.tgz",
+      "integrity": "sha512-zAX0VCi+2g7B6+ZxzRCT6B4o42ytkGa9qXYIh9DqCko82vLXq939DFDfRV5KufUuzZeR1Pc7z8X28FiqLCbidQ==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/nightly-playground/package.json
+++ b/nightly-playground/package.json
@@ -22,7 +22,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@opensearch-project/opensearch-cluster-cdk": "1.2.1",
+    "@opensearch-project/opensearch-cluster-cdk": "1.2.2",
     "@types/babel__traverse": "^7.18.2",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -59,7 +59,7 @@ test('Ensure security is always enabled with custom role mapping', () => {
               ignoreErrors: false,
             },
             '017': {
-              command: "set -ex;cd opensearch-dashboards/config; echo \"opensearch_security.auth.anonymous_auth_enabled: 'true'\nopensearch.password: undefined\n\">additionalOsdConfig.yml; yq eval-all -i '. as $item ireduce ({}; . * $item)' opensearch_dashboards.yml additionalOsdConfig.yml -P",
+              command: "set -ex;cd opensearch-dashboards/config; echo \"opensearch_security.auth.anonymous_auth_enabled: 'true'\nopensearch.password: undefined\nopensearch_security.cookie.secure: 'true'\nopensearch_security.cookie.isSameSite: None\n\">additionalOsdConfig.yml; yq eval-all -i '. as $item ireduce ({}; . * $item)' opensearch_dashboards.yml additionalOsdConfig.yml -P",
               cwd: '/home/ec2-user',
               ignoreErrors: false,
             },


### PR DESCRIPTION
### Description
Since we are using external certificate for nightly playground (ACM) in this case based on the domain name, this change adds the additional config for opensearch-dashboards. 

```
"opensearch_security.cookie.secure": "true"
"opensearch_security.cookie.isSameSite": "None"
```

### Issues Resolved
#129 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
