### PR TITLE
Deploy 2.13.0

### DIFF
--- a/.github/workflows/deploy-nightly-playground.yml
+++ b/.github/workflows/deploy-nightly-playground.yml
@@ -7,7 +7,7 @@ on:
 
 
 env:
-  DIST_VERSION: 2.11.0
+  DIST_VERSION: 2.13.0
 
 jobs:
   set-os-osd-urls:
@@ -76,7 +76,7 @@ jobs:
         run: |
           npm install
           npm run cdk bootstrap -- -c distVersion=${DIST_VERSION} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }}
-          npm run cdk deploy "*" -- -c distVersion=${DIST_VERSION} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} --require-approval never --outputs-file output.json
+          npm run cdk deploy "*" -- -c distVersion=${DIST_VERSION} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} -c adminPassword=${{ SECRETS.OPENSEARCH_PASSWORD }} --require-approval never --outputs-file output.json
 
           yq e '.. | select(has("loadbalancerurl")) | .loadbalancerurl' output.json
           echo "ENDPOINT=$(aws cloudformation --region us-west-2 describe-stacks --stack-name infraStack-2x --query 'Stacks[0].Outputs[0].OutputValue' --output text)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description
Now that we know nightly playground works well, moving the deployment from 2.11.0 to 2.13.0

### Issues Resolved
#129 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
