### PR TITLE
Change stack dependency and update readme

### DIFF
--- a/nightly-playground/README.md
+++ b/nightly-playground/README.md
@@ -1,6 +1,6 @@
 # OpenSearch Nightly Playground
 
-This project is an extension of [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk) that deploys nightly built artifacts daily. The source code concentrates on taking care of regular deployments, permissions, access, etc. For more customization, please feel free to directly use [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk).
+This project is an extension of [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk). It deploys nightly built artifacts daily. The source code concentrates on taking care of regular deployments, non-default permissions, access, etc. For more customization, please feel free to directly use [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk).
 
 ## Getting Started
 
@@ -14,14 +14,15 @@ This project is an extension of [opensearch-cluster-cdk](https://github.com/open
 
 In order to deploy the stack the user needs to provide a set of required parameters listed below:
 
-| Name                          | Requirement | Type      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|-------------------------------|:------------|:------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| distVersion                   | Required    | string      | The OpenSearch distribution version (released/un-released) the user wants to deploy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| distributionUrl              | Required    | string     | OpenSearch tarball distribution URL plugin                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| dashboardsUrl                 | Required    | string      | OpenSearch-Dashboards tarball distribution URL version                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Name                          | Requirement | Type      | Description   |
+|-------------------------------|:------------|:----------|:------------|
+| distVersion                   | Required    | string      | The OpenSearch distribution version (released/un-released) the user wants to deploy  |
+| distributionUrl               | Required    | string      | OpenSearch tarball distribution URL plugin  |
+| dashboardsUrl                 | Required    | string      | OpenSearch-Dashboards tarball distribution URL version  |
+| dashboardPassword             | Required    | string      | OpenSearch-Dashboards password for kibanaserver user |
 
-#### Sample command to set up multi-node cluster with security enabled
+#### Sample command to set up nighly playground cluster
 
 ```
-npm run cdk deploy "*" -- -c distVersion=2.3.0 -c distributionUrl=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.3.0/latest/linux/x64/tar/dist/opensearch/opensearch-2.3.0-linux-x64.tar.gz -c dashboardsUrl=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.3.0/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-2.3.0-linux-x64.tar.gz
+npm run cdk deploy "*" -- -c distVersion=2.3.0 -c distributionUrl=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.3.0/latest/linux/x64/tar/dist/opensearch/opensearch-2.3.0-linux-x64.tar.gz -c dashboardsUrl=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.3.0/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-2.3.0-linux-x64.tar.gz -c dashboardPassword=fooBar
 ```

--- a/nightly-playground/lib/nightly-playground-stack.ts
+++ b/nightly-playground/lib/nightly-playground-stack.ts
@@ -53,8 +53,6 @@ export class NightlyPlaygroundStack {
     });
 
     this.stacks.push(networkStack);
-    networkStack.addDependency(commonToolsStack);
-
     // @ts-ignore
     const infraStack = new InfraStack(scope, `infraStack-${id}`, {
       ...props,
@@ -77,5 +75,6 @@ export class NightlyPlaygroundStack {
     this.stacks.push(infraStack);
 
     infraStack.addDependency(networkStack);
+    infraStack.addDependency(commonToolsStack);
   }
 }


### PR DESCRIPTION
### Description
The commonToolsStack is only required by infra stack. Hence changing the dependency from network stack to infra stack.
Also update the readme with new Params

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
