### PR TITLE
Fix context variable name and workflow permissions

### DIFF
--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           npm install
           playground_id=`echo ${{inputs.dist_version}} | cut -d. -f1`x
-          npm run cdk deploy "infraStack*" -- -c playgroundId=$playground_id -c distVersion=${{inputs.dist_version}} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} -c adminPassword=${{ SECRETS.OPENSEARCH_PASSWORD }} --require-approval never --outputs-file output.json
+          npm run cdk deploy "infraStack*" -- -c playGroundId=$playground_id -c distVersion=${{inputs.dist_version}} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} -c adminPassword=${{ SECRETS.OPENSEARCH_PASSWORD }} --require-approval never --outputs-file output.json
 
           yq e '.. | select(has("loadbalancerurl")) | .loadbalancerurl' output.json
           echo "ENDPOINT=$(aws cloudformation --region us-west-2 describe-stacks --stack-name infraStack-$playground_id --query 'Stacks[0].Outputs[0].OutputValue' --output text)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -11,10 +11,14 @@ jobs:
       matrix:
         dist_version: ['2.13.0', '3.0.0']
     uses: opensearch-project/opensearch-devops/.github/workflows/nightly-playground-deploy.yml@main
+    secrets: inherit
     with:
       dist_version: ${{ matrix.dist_version }}
 
   update-ngnix-config:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     needs: deploy-nightly-playground
     steps:
@@ -33,4 +37,4 @@ jobs:
         working-directory: nightly-playground
         run: |
           npm install
-          npm run cdk deploy "ngnixBased*" -- -c playgroundId=3x -c distVersion="3.0.0" -c distributionUrl="someUrl" -c dashboardsUrl="someUrl" -c dashboardPassword="somePassword" -c adminPassword="somePassword" -c endpoint2x=${{needs.deploy-nightly-playground.outputs.endpoint_2x}} -c endpoint3x=${{needs.deploy-nightly-playground.outputs.endpoint_3x}} --require-approval never
+          npm run cdk deploy "ngnixBased*" -- -c playGroundId=3x -c distVersion="3.0.0" -c distributionUrl="someUrl" -c dashboardsUrl="someUrl" -c dashboardPassword="somePassword" -c adminPassword="somePassword" -c endpoint2x=${{needs.deploy-nightly-playground.outputs.endpoint_2x}} -c endpoint3x=${{needs.deploy-nightly-playground.outputs.endpoint_3x}} --require-approval never


### PR DESCRIPTION
### Description
With the workflow trigger being changed from workflow_dispatch to workflow_call, the workflow needs additional permissions `secrets: inherit` in this case to assume the credentials. 
Also updates the permissions for ngnix stack and fixes context variable name

### Issues Resolved
related to #129 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
