### PR TITLE
Fix the outputs of deploy step

### DIFF
--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -109,8 +109,8 @@ jobs:
 
   assign-ouput-values:
     outputs:
-      endpoint_2x: ${{ steps.assign.outputs.endpoint2x }}
-      endpoint_3x: ${{ steps.assign.outputs.endpoint3x }}
+      endpoint_2x: ${{ steps.assign.outputs.endpoint_2x }}
+      endpoint_3x: ${{ steps.assign.outputs.endpoint_3x }}
     needs: 
       - validate-and-deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
The endpoints passed to ngnix stack were empty due to typo in the variable name. This PR fixes it.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
