### PR TITLE
Add snapshot S3 bucket and custome role

### DIFF
--- a/nightly-playground/lib/common-tools-stack.ts
+++ b/nightly-playground/lib/common-tools-stack.ts
@@ -8,6 +8,7 @@ compatible open source license. */
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
 import { HostedZone } from 'aws-cdk-lib/aws-route53';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 export class CommonToolsStack extends Stack {
@@ -27,5 +28,9 @@ export class CommonToolsStack extends Stack {
         validation: CertificateValidation.fromDns(route53HostedZone),
       });
       this.certificateArn = certificate.certificateArn;
+
+      const snapshotS3Bucket = new Bucket(this, 'snapshotS3Bucket', {
+        bucketName: 'nightly-playgrounds-snapshots-bucket',
+      });
     }
 }

--- a/nightly-playground/lib/common-tools-stack.ts
+++ b/nightly-playground/lib/common-tools-stack.ts
@@ -7,30 +7,60 @@ compatible open source license. */
 
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
+import {
+  Effect, ManagedPolicy, PolicyStatement, Role, ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { HostedZone } from 'aws-cdk-lib/aws-route53';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 export class CommonToolsStack extends Stack {
-    readonly certificateArn: string
+  readonly certificateArn: string
 
-    readonly zone = 'playground.nightly.opensearch.org'
+  public readonly customRole: Role
 
-    constructor(scope: Construct, id: string, props: StackProps) {
-      super(scope, id, props);
+  readonly zone = 'playground.nightly.opensearch.org'
 
-      const route53HostedZone = new HostedZone(this, 'nigghhtlyHostedZone', {
-        zoneName: this.zone,
-      });
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
 
-      const certificate = new Certificate(this, 'cert', {
-        domainName: this.zone,
-        validation: CertificateValidation.fromDns(route53HostedZone),
-      });
-      this.certificateArn = certificate.certificateArn;
+    const route53HostedZone = new HostedZone(this, 'nigghhtlyHostedZone', {
+      zoneName: this.zone,
+    });
 
-      const snapshotS3Bucket = new Bucket(this, 'snapshotS3Bucket', {
-        bucketName: 'nightly-playgrounds-snapshots-bucket',
-      });
-    }
+    const certificate = new Certificate(this, 'cert', {
+      domainName: this.zone,
+      validation: CertificateValidation.fromDns(route53HostedZone),
+    });
+    this.certificateArn = certificate.certificateArn;
+
+    this.customRole = new Role(this, 'customInstanceRole', {
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ReadOnlyAccess'),
+        ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy'),
+        ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')],
+      assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+    });
+
+    const snapshotS3Bucket = new Bucket(this, 'snapshotS3Bucket', {
+      bucketName: 'nightly-playgrounds-snapshots-bucket',
+    });
+
+    const s3bucketPolicyStatement = new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: [
+        's3:ListBucket',
+        's3:GetBucketLocation',
+        's3:ListBucketMultipartUploads',
+        's3:ListBucketVersions',
+        's3:GetObject',
+        's3:PutObject',
+        's3:DeleteObject',
+        's3:AbortMultipartUpload',
+        's3:ListMultipartUploadParts',
+      ],
+      resources: [snapshotS3Bucket.bucketArn, `${snapshotS3Bucket.bucketArn}/*`],
+    });
+
+    this.customRole.addToPolicy(s3bucketPolicyStatement);
+  }
 }

--- a/nightly-playground/lib/nightly-playground-stack.ts
+++ b/nightly-playground/lib/nightly-playground-stack.ts
@@ -79,9 +79,9 @@ export class NightlyPlaygroundStack {
       certificateArn: commonToolsStack.certificateArn,
       mapOpensearchPortTo: 8443,
       mapOpensearchDashboardsPortTo: 443,
+      customRoleArn: commonToolsStack.customRole.roleArn,
     });
     this.stacks.push(infraStack);
-
     infraStack.addDependency(networkStack);
 
     const endpoint2x = scope.node.tryGetContext('endpoint2x');

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -140,8 +140,59 @@ test('Test commons stack resources', () => {
     Name: 'playground.nightly.opensearch.org.',
   });
   commonsStackTemplate.resourceCountIs('AWS::S3::Bucket', 1);
+  commonsStackTemplate.resourceCountIs('AWS::IAM::Role', 1);
+  commonsStackTemplate.resourceCountIs('AWS::IAM::Policy', 1);
   commonsStackTemplate.hasResourceProperties('AWS::S3::Bucket', {
     BucketName: 'nightly-playgrounds-snapshots-bucket',
+  });
+  commonsStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            's3:ListBucket',
+            's3:GetBucketLocation',
+            's3:ListBucketMultipartUploads',
+            's3:ListBucketVersions',
+            's3:GetObject',
+            's3:PutObject',
+            's3:DeleteObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+          ],
+          Effect: 'Allow',
+          Resource: [
+            {
+              'Fn::GetAtt': [
+                'snapshotS3Bucket9CDAA6D3',
+                'Arn',
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  {
+                    'Fn::GetAtt': [
+                      'snapshotS3Bucket9CDAA6D3',
+                      'Arn',
+                    ],
+                  },
+                  '/*',
+                ],
+              ],
+            },
+          ],
+        },
+      ],
+      Version: '2012-10-17',
+    },
+    PolicyName: 'customInstanceRoleDefaultPolicy5AD458B6',
+    Roles: [
+      {
+        Ref: 'customInstanceRole001450EE',
+      },
+    ],
   });
   commonsStackTemplate.hasResourceProperties('AWS::CertificateManager::Certificate', {
     DomainName: 'playground.nightly.opensearch.org',

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -139,6 +139,10 @@ test('Test commons stack resources', () => {
   commonsStackTemplate.hasResourceProperties('AWS::Route53::HostedZone', {
     Name: 'playground.nightly.opensearch.org.',
   });
+  commonsStackTemplate.resourceCountIs('AWS::S3::Bucket', 1);
+  commonsStackTemplate.hasResourceProperties('AWS::S3::Bucket', {
+    BucketName: 'nightly-playgrounds-snapshots-bucket',
+  });
   commonsStackTemplate.hasResourceProperties('AWS::CertificateManager::Certificate', {
     DomainName: 'playground.nightly.opensearch.org',
     DomainValidationOptions: [


### PR DESCRIPTION
### Description
- Add snapshot S3 bucket that will be used to store cluster snapshots and restore relevant indices from other snapshots
- Also adds custom role with additional permissions for S3 bucket. Separating the role from the default one gave us more control on the type of policy and permissions we might want to add in future too.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
