### PR TITLE
Bump 2x plyaground to 2.14.0

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.13.0', '3.0.0']
+        dist_version: ['2.14.0', '3.0.0']
     uses: opensearch-project/opensearch-devops/.github/workflows/nightly-playground-deploy.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
### Description
After checking the validation for 2.14.0 https://build.ci.opensearch.org/job/distribution-validation/406/console its finally time to move on to 2.14.0 release for 2x endpoint

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
