### PR TITLE
Enable restoring alerting config from snapshots

### DIFF
--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -148,10 +148,10 @@ jobs:
               "base_path": "${{needs.validate-and-deploy.outputs.PLAYGROUND_ID}}"
             }
           }' -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure
-      # - name: Restore altering configs
-      #   run: |
-      #     curl -XPOST "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_snapshot/snapshots-repo/<replace_with_snapshot_id>/_restore" -H 'Content-Type: application/json' -d'
-      #     {
-      #       "indices": ".opendistro-alerting-config,.opensearch-notifications-config",
-      #       "ignore_unavailable": false,
-      #     }' -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure
+      - name: Restore altering configs
+        run: |
+          curl -XPOST "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_snapshot/snapshots-repo/alerts-config/_restore" -H 'Content-Type: application/json' -d'
+          {
+            "indices": ".opendistro-alerting-config,.opensearch-notifications-config",
+            "ignore_unavailable": false,
+          }' -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure


### PR DESCRIPTION
### Description
We have manually added monitors for below:
- Red cluster
- High JVM
- Node drop

This PR will keep restoring those config into newly deployed clusters by reindexing `.opendistro-alerting-config,.opensearch-notifications-config` back to the cluster. 

### Issues Resolved
#132 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
