### PR TITLE
Set fail-fast to false for nightly deployments

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,7 +9,8 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.14.0', '3.0.0']
+        dist_version: ['2.13.0', '3.0.0']
+      fail-fast: false
     uses: opensearch-project/opensearch-devops/.github/workflows/nightly-playground-deploy.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,9 +9,9 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.13.0', '3.0.0']
+        dist_version: ['2.14.0', '3.0.0']
       fail-fast: false
-    uses: opensearch-project/opensearch-devops/.github/workflows/nightly-playground-deploy.yml@main
+    uses: ./.github/workflows/nightly-playground-deploy.yml
     secrets: inherit
     with:
       dist_version: ${{ matrix.dist_version }}


### PR DESCRIPTION
### Description
As of now, if one of the version fails to deploy the other fails to deploy as well. Setting fail fast to false allows to decouple both the deployments. Example workflow run: https://github.com/gaiksaya/opensearch-devops/actions/runs/8767748504/job/24061359684

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
