### PR TITLE
Disable WAF for NLB and only deploy infraStack

### DIFF
--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -78,7 +78,7 @@ jobs:
           npm install
           playground_id=`echo ${{inputs.dist_version}} | cut -d. -f1`x
           echo "PLAYGROUND_ID=$playground_id" >> "$GITHUB_OUTPUT"
-          npm run cdk deploy "*" -- -c playGroundId=$playground_id -c distVersion=${{inputs.dist_version}} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} -c adminPassword=${{ SECRETS.OPENSEARCH_PASSWORD }} -c endpoint2x=${{secrets.endpoint_2x}} -c endpoint3x=${{secrets.endpoint_3x}} --require-approval never
+          npm run cdk deploy "infra*" -- -c playGroundId=$playground_id -c distVersion=${{inputs.dist_version}} -c distributionUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_URL}} -c dashboardsUrl=${{needs.set-os-osd-urls.outputs.OPENSEARCH_DASHBOARDS_URL}} -c dashboardPassword=${{ SECRETS.DASHBOARDS_PASSWORD }} -c adminPassword=${{ SECRETS.OPENSEARCH_PASSWORD }} -c endpoint2x=${{secrets.endpoint_2x}} -c endpoint3x=${{secrets.endpoint_3x}} --require-approval never
 
           echo "ENDPOINT=$(aws cloudformation --region us-west-2 describe-stacks --stack-name infraStack-$playground_id --query 'Stacks[0].Outputs[1].OutputValue' --output text)" >> "$GITHUB_OUTPUT"
 
@@ -102,6 +102,7 @@ jobs:
   configure-alerts-notifications:
     needs: validate-and-deploy
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Create notification channel
         run : |
@@ -123,7 +124,7 @@ jobs:
       - name: Configure monitors
         run: |
           for config in `ls nightly-playground/resources/monitors-config/`;
-          do curl -XPOST "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_alerting/monitors" -H 'Content-Type: application/json' -d @nightly-playground/resources/monitors-config/$config -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure;
+          do curl -XPOST -f "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_alerting/monitors" -H 'Content-Type: application/json' -d @nightly-playground/resources/monitors-config/$config -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure;
           done
 
   add-sample-data:

--- a/nightly-playground/lib/nightly-playground-stack.ts
+++ b/nightly-playground/lib/nightly-playground-stack.ts
@@ -103,13 +103,10 @@ export class NightlyPlaygroundStack {
 
     const wafStack = new NightlyPlaygroundWAF(scope, 'wafStack', {
       ...props,
-      playgroundId: playGroundId,
       ngnixLoadBalancer: routingStack.alb,
-      infraStackLoadBalancer: infraStack.nlb,
     });
 
     this.stacks.push(wafStack);
-    wafStack.addDependency(infraStack);
     wafStack.addDependency(routingStack);
   }
 }

--- a/nightly-playground/lib/waf.ts
+++ b/nightly-playground/lib/waf.ts
@@ -1,5 +1,5 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
-import { ApplicationLoadBalancer, NetworkLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { CfnWebACL, CfnWebACLAssociation, CfnWebACLAssociationProps } from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 
@@ -105,8 +105,6 @@ export class WebACLAssociation extends CfnWebACLAssociation {
 }
 
 export interface WafProps extends StackProps{
-    playgroundId : string;
-    infraStackLoadBalancer: NetworkLoadBalancer;
     ngnixLoadBalancer: ApplicationLoadBalancer;
 }
 
@@ -115,10 +113,6 @@ export class NightlyPlaygroundWAF extends Stack {
     super(scope, id, props);
     const waf = new WAF(this, 'WAFv2');
     // Create an association with the alb
-    new WebACLAssociation(this, `wafALBassociation-${props.playgroundId}`, {
-      resourceArn: props.infraStackLoadBalancer.loadBalancerArn,
-      webAclArn: waf.attrArn,
-    });
     new WebACLAssociation(this, 'wafALBassociation-ngnix', {
       resourceArn: props.ngnixLoadBalancer.loadBalancerArn,
       webAclArn: waf.attrArn,

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -336,7 +336,7 @@ test('WAF resources', () => {
   const wafStackTemplate = Template.fromStack(wafStack);
 
   wafStackTemplate.resourceCountIs('AWS::WAFv2::WebACL', 1);
-  wafStackTemplate.resourceCountIs('AWS::WAFv2::WebACLAssociation', 2);
+  wafStackTemplate.resourceCountIs('AWS::WAFv2::WebACLAssociation', 1);
   wafStackTemplate.hasResourceProperties('AWS::WAFv2::WebACL', {
     DefaultAction: {
       Allow: {},


### PR DESCRIPTION
### Description
As per WAF documentation, only following formats are supported 

```
     * - For an Application Load Balancer: `arn:aws:elasticloadbalancing: *region* : *account-id* :loadbalancer/app/ *load-balancer-name* / *load-balancer-id*`
     * - For an Amazon API Gateway REST API: `arn:aws:apigateway: *region* ::/restapis/ *api-id* /stages/ *stage-name*`
     * - For an AWS AppSync GraphQL API: `arn:aws:appsync: *region* : *account-id* :apis/ *GraphQLApiId*`
```
Since this clusters use NLB need to come up with another solution
* Also only deploys infraStack using workflow. Since 2x and 3x runs simultaneously, the cloudformation status check fails the stack update saying `CREATE_IN_PROGRESS state and can not be updated` See https://github.com/opensearch-project/opensearch-devops/actions/runs/8902202666/job/24447695425
* Also makes the job to add alerts optional as notification and alerting plugin may or may not be the part of the deploying distribution

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
