### PR TITLE
Add a check for existing notification channel

### DIFF
--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           status_code=$(curl -XGET -s -o /dev/null -w "%{http_code}" "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_notifications/configs/slack-notification-channel" -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure)
 
-          if [ $status_code != 200 ]; then
+          if [ "$status_code" != "200" ]; then
             curl -XPOST -f "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_notifications/configs" -H 'Content-Type: application/json' -d'
             {
               "config_id": "slack-notification-channel",

--- a/.github/workflows/nightly-playground-deploy.yml
+++ b/.github/workflows/nightly-playground-deploy.yml
@@ -104,22 +104,27 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - name: Create notification channel
-        run : |
-          curl -XPOST -f "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_notifications/configs" -H 'Content-Type: application/json' -d'
-          {
-            "config_id": "slack-notification-channel",
-            "name": "slack-notification-channel",
-            "config": {
+
+      - name: Check and Create notification channel
+        run: |
+          status_code=$(curl -XGET -s -o /dev/null -w "%{http_code}" "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_notifications/configs/slack-notification-channel" -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure)
+
+          if [ $status_code != 200 ]; then
+            curl -XPOST -f "https://${{needs.validate-and-deploy.outputs.ENDPOINT}}:8443/_plugins/_notifications/configs" -H 'Content-Type: application/json' -d'
+            {
+              "config_id": "slack-notification-channel",
               "name": "slack-notification-channel",
-              "description": "Slack notification channel for monitoring alerts",
-              "config_type": "webhook",
-              "is_enabled": true,
-              "webhook": {
-                "url": "${{ secrets.SLACK_WEBHOOK }}"
+              "config": {
+                "name": "slack-notification-channel",
+                "description": "Slack notification channel for monitoring alerts",
+                "config_type": "webhook",
+                "is_enabled": true,
+                "webhook": {
+                  "url": "${{ secrets.SLACK_WEBHOOK }}"
+                  }
                 }
-              }
-            }' -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure
+              }' -u ${{ secrets.OPENSEARCH_USER }}:${{ secrets.OPENSEARCH_PASSWORD }} --insecure
+          fi
 
       - name: Configure monitors
         run: |


### PR DESCRIPTION
### Description
For runs that do not actually update the stack, the deployment still shows successful moving to next step.While indexing and adding sample data works, adding an already existing channel throws [409](https://github.com/opensearch-project/opensearch-devops/actions/runs/8913867098/job/24480310602)
This PR adds check and only adds the channel if it is missing

### Issues Resolved
#132 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
