### PR TITLE
Fix homepage for nightly

### DIFF
--- a/nightly-playground/lib/routing.ts
+++ b/nightly-playground/lib/routing.ts
@@ -116,7 +116,8 @@ export class Routing extends Stack {
                     proxy_set_header X-Forwarded-Proto $scheme;  # Set the X-Forwarded-Proto header
                 }
               }`),
-      InitFile.fromFileInline('/usr/share/nginx/html/index.html', join(__dirname, '../resources/assets/ngnix-index.html')),
+      InitFile.fromFileInline('/usr/share/nginx/html/index_nightly.html', join(__dirname, '../resources/assets/ngnix-index.html')),
+      InitCommand.shellCommand('cp /usr/share/nginx/html/index_nightly.html /usr/share/nginx/html/index.html'),
       InitCommand.shellCommand('sudo systemctl start nginx'),
       InitCommand.shellCommand('sudo systemctl enable nginx'),
     ];

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -301,9 +301,12 @@ test('ngnix load balancer and ASG resources', () => {
               command: "openssl req -x509 -nodes -newkey rsa:4096 -keyout /etc/nginx/cert.key -out /etc/nginx/cert.crt -days 365 -subj '/CN=SH'",
             },
             '002': {
-              command: 'sudo systemctl start nginx',
+              command: 'cp /usr/share/nginx/html/index_nightly.html /usr/share/nginx/html/index.html',
             },
             '003': {
+              command: 'sudo systemctl start nginx',
+            },
+            '004': {
               command: 'sudo systemctl enable nginx',
             },
           },


### PR DESCRIPTION
### Description
For some reason (or by design) the aws cdk writes the file first and the executes the shell commands no matter what. Since ngnix is installed after writing the file to `/usr/share/nginx/html/index.html` the package overwrites it with default one during execution. However, for non-default files like `/etc/nginx/conf.d/opensearchdashboard.conf` and `/usr/share/nginx/html/index_nightly.html`, are retained. Hence modifying the implementation a to accommodate this behavior 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
