### PR TITLE
Bump nightly playgrounds to 2.17

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.16.0', '3.0.0']
+        dist_version: ['2.17.0', '3.0.0']
       fail-fast: false
     uses: ./.github/workflows/nightly-playground-deploy.yml
     secrets: inherit


### PR DESCRIPTION
### Description
Bump nightly playgrounds to 2.17

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4908

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
