### PR TITLE
Map users by default to read-only role and add another one for admin

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.17.0', '3.0.0']
+        dist_version: ['2.18.0', '3.0.0']
       fail-fast: false
     uses: ./.github/workflows/nightly-playground-deploy.yml
     secrets: inherit

--- a/nightly-playground/resources/security-config/roles_mapping.yml
+++ b/nightly-playground/resources/security-config/roles_mapping.yml
@@ -10,12 +10,14 @@ _meta:
 opendistro_security_anonymous_role:
   backend_roles:
     - "opendistro_security_anonymous_backendrole"
+    - "default-roles-opensearch-nightly-playgrounds"
 ## Demo roles mapping
 
 all_access:
   reserved: false
   backend_roles:
     - "admin"
+    - "admin_role_for_nightly"
   description: "Maps admin to all_access"
 
 own_index:

--- a/nightly-playground/test/nightly-playground.test.ts
+++ b/nightly-playground/test/nightly-playground.test.ts
@@ -47,7 +47,7 @@ test('Ensure security is always enabled with custom role mapping', () => {
               ignoreErrors: false,
             },
             '011': {
-              command: "set -ex; echo \"_meta:\n  type: rolesmapping\n  config_version: 2\nopendistro_security_anonymous_role:\n  backend_roles:\n    - opendistro_security_anonymous_backendrole\nall_access:\n  reserved: false\n  backend_roles:\n    - admin\n  description: Maps admin to all_access\nown_index:\n  reserved: false\n  users:\n    - '*'\n  description: Allow full access to an index named like the username\nkibana_user:\n  reserved: false\n  backend_roles:\n    - kibanauser\n  description: Maps kibanauser to kibana_user\nreadall:\n  reserved: false\n  backend_roles:\n    - readall\nkibana_server:\n  reserved: true\n  users:\n    - kibanaserver\n\" > opensearch/config/opensearch-security/roles_mapping.yml",
+              command: "set -ex; echo \"_meta:\n  type: rolesmapping\n  config_version: 2\nopendistro_security_anonymous_role:\n  backend_roles:\n    - opendistro_security_anonymous_backendrole\n    - default-roles-opensearch-nightly-playgrounds\nall_access:\n  reserved: false\n  backend_roles:\n    - admin\n    - admin_role_for_nightly\n  description: Maps admin to all_access\nown_index:\n  reserved: false\n  users:\n    - '*'\n  description: Allow full access to an index named like the username\nkibana_user:\n  reserved: false\n  backend_roles:\n    - kibanauser\n  description: Maps kibanauser to kibana_user\nreadall:\n  reserved: false\n  backend_roles:\n    - readall\nkibana_server:\n  reserved: true\n  users:\n    - kibanaserver\n\" > opensearch/config/opensearch-security/roles_mapping.yml",
               cwd: '/home/ec2-user',
               ignoreErrors: false,
             },


### PR DESCRIPTION
### Description
Created a new backend role in keycloak `admin_role_for_nightly` where users will have admin access. 
For all other user, `default-roles-opensearch-nightly-playgrounds` is default role via keycloak. Mapping it to readonly users.
Also bump version to 2.18

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
