### PR TITLE
Upgrade keycloak to 26.0.0

### DIFF
--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,14 +1,30 @@
-# CDK to deploy Keycloak infrastructure
+# CDK for deploying Keycloak
 
-This is a blank project for CDK development with TypeScript.
+Using this project you can deploy keycloak as a service on AWS.
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+## Getting Started
+
+- Requires [NPM](https://docs.npmjs.com/cli/v7/configuring-npm/install) to be installed
+- Install project dependencies using `npm install` from this project directory
+- Configure [aws credentials](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_prerequisites)
+
+
+* Ensure that your AWS CLI is correctly configured with access credentials.
+* Also ensure that you're running these commands in the current directory
+* Next, install the required dependencies:
+
+```
+npm install
+```
 
 ## Useful commands
 
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `npx cdk deploy`  deploy this stack to your default AWS account/region
-* `npx cdk diff`    compare deployed stack with current state
-* `npx cdk synth`   emits the synthesized CloudFormation template
+`npm run cdk deploy *`  deploys below stacks to your default AWS account/region:
+
+* keycloakVPC - Deploys networking resources.
+* KeyCloakUtils - Deploys utility stack that contains resources such as hosted zone, secrets, certificates, etc.
+* KeycloakRDS - Deploys RDS related resources.
+* PublicKeycloak - Deploys keycloak using docker image with admin interface disabled.
+* InternalKeycloak (optional) - Deploys internally facing keycloak with admin interface enabled.
+* KeycloakWAFstack - Deploys stacks containing WAF rules and attached to load balancer(s).
+

--- a/keycloak/resources/docker-compose.yml
+++ b/keycloak/resources/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   keycloak:
     restart: on-failure
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:24.0.4
+    image: quay.io/keycloak/keycloak:26.0.0
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://${RDS_HOSTNAME_WITH_PORT}/keycloak
@@ -12,7 +12,7 @@ services:
       KC_DB_PASSWORD: ${KC_DB_PASSWORD}
       KC_HTTPS_CERTIFICATE_FILE: /opt/certs/keycloak.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/certs/keycloak.key
-      KC_FEATURES_DISABLED: 'admin-api,admin2'
+      KC_FEATURES_DISABLED: 'admin-api,admin'
       KC_HEALTH_ENABLED: true
     command: start
     volumes:

--- a/keycloak/resources/internal-docker-compose.yml
+++ b/keycloak/resources/internal-docker-compose.yml
@@ -3,7 +3,7 @@ services:
   keycloak:
     restart: on-failure
     container_name: keycloakInternal
-    image: quay.io/keycloak/keycloak:24.0.4
+    image: quay.io/keycloak/keycloak:26.0.0
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://${RDS_HOSTNAME_WITH_PORT}/keycloak


### PR DESCRIPTION
### Description
Upgrade keycloak to 26.0.0. Also updates readme. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
