### PR TITLE
Bump version to 3.0 GA

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-nightly-playground:
     strategy:
       matrix:
-        dist_version: ['2.19.2', '3.0.0-beta1']
+        dist_version: ['2.19.2', '3.0.0']
       fail-fast: false
     uses: ./.github/workflows/nightly-playground-deploy.yml
     secrets: inherit


### PR DESCRIPTION
### Description
Bump version to 3.0 GA as beta1 is out now. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
