### PR TITLE
Upgrade cluster cdk to 1.4.0

### DIFF
--- a/nightly-playground/package-lock.json
+++ b/nightly-playground/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nightly-playground",
       "version": "0.1.0",
       "dependencies": {
-        "@opensearch-project/opensearch-cluster-cdk": "1.3.0",
+        "@opensearch-project/opensearch-cluster-cdk": "1.4.0",
         "@types/babel__traverse": "^7.18.2",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.3.0.tgz",
-      "integrity": "sha512-Rl27DCA18ibfDA0DkmMFDfISOo/HZfCicPLqrpS3y3iWx4foL9yWMfqM7Z5DnxiMB/daHAm7pn/M65jAWZuL0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.4.0.tgz",
+      "integrity": "sha512-m3hJA6X2iGG0tiO1127aOWjNkfeGJEre+JPbEB3UyRM7IQXgNlXLqTRshpeFip+RxFm9uANhwpnxj5+AhWaLYQ==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -8104,9 +8104,9 @@
       }
     },
     "@opensearch-project/opensearch-cluster-cdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.3.0.tgz",
-      "integrity": "sha512-Rl27DCA18ibfDA0DkmMFDfISOo/HZfCicPLqrpS3y3iWx4foL9yWMfqM7Z5DnxiMB/daHAm7pn/M65jAWZuL0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch-cluster-cdk/-/opensearch-cluster-cdk-1.4.0.tgz",
+      "integrity": "sha512-m3hJA6X2iGG0tiO1127aOWjNkfeGJEre+JPbEB3UyRM7IQXgNlXLqTRshpeFip+RxFm9uANhwpnxj5+AhWaLYQ==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/nightly-playground/package.json
+++ b/nightly-playground/package.json
@@ -23,7 +23,7 @@
     "@types/semver": "^7.5.6"
   },
   "dependencies": {
-    "@opensearch-project/opensearch-cluster-cdk": "1.3.0",
+    "@opensearch-project/opensearch-cluster-cdk": "1.4.0",
     "@types/babel__traverse": "^7.18.2",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",


### PR DESCRIPTION
### Description
Upgrade cluster cdk to 1.4.0 that comes with few dependency bumps and few new features. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
