### PR TITLE
Remove problematic use of read cmd with -d param

### DIFF
--- a/nightly-playground/scripts/search_relevance.sh
+++ b/nightly-playground/scripts/search_relevance.sh
@@ -60,22 +60,27 @@ exe curl -XPOST "$OPENSEARCH_SERVER_URL/ubi_queries/_refresh" -u $OPENSEARCH_USE
 echo
 exe curl -XPOST "$OPENSEARCH_SERVER_URL/ubi_events/_refresh" -u $OPENSEARCH_USER:$OPENSEARCH_PASSWORD -k
 
-read -r -d '' QUERY_BODY << EOF
-{
+exe curl -s -XGET "$OPENSEARCH_SERVER_URL/ubi_queries/_search" -u $OPENSEARCH_USER:$OPENSEARCH_PASSWORD -k \
+-H "Content-type: application/json" \
+-d'{
   "query": {
     "match_all": {}
   },
   "size": 0
-}
-EOF
+}'
 
-NUMBER_OF_QUERIES=$(exe curl -s -XGET "$OPENSEARCH_SERVER_URL/ubi_queries/_search" -u $OPENSEARCH_USER:$OPENSEARCH_PASSWORD -k \
-  -H "Content-Type: application/json" \
-  -d "${QUERY_BODY}" | jq -r '.hits.total.value') \
+NUMBER_OF_QUERIES=`jq -r '.hits.total.value' < RES`
 
-NUMBER_OF_EVENTS=$(exe curl -s -XGET "$OPENSEARCH_SERVER_URL/ubi_events/_search" -u $OPENSEARCH_USER:$OPENSEARCH_PASSWORD -k \
-  -H "Content-Type: application/json" \
-  -d "${QUERY_BODY}" | jq -r '.hits.total.value')
+exe curl -s -XGET "$OPENSEARCH_SERVER_URL/ubi_events/_search" -u $OPENSEARCH_USER:$OPENSEARCH_PASSWORD -k \
+-H "Content-type: application/json" \
+-d'{
+  "query": {
+    "match_all": {}
+  },
+  "size": 0
+}'
+
+NUMBER_OF_EVENTS=`jq -r '.hits.total.value' < RES`
   
 echo
 echo "Indexed UBI data: $NUMBER_OF_QUERIES queries and $NUMBER_OF_EVENTS events"


### PR DESCRIPTION
### Description
Currently we are failing with the `read` command due to it not supporting a `-d` property in the version of shell we are using.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
