### PR TITLE
Bump nightly to 3.6.0 and 2.19.5

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-devops'
     strategy:
       matrix:
-        dist_version: ['2.19.4', '3.5.0']
+        dist_version: ['2.19.5', '3.6.0']
       fail-fast: false
     uses: ./.github/workflows/nightly-playground-deploy.yml
     secrets: inherit


### PR DESCRIPTION
### Description
Bumps nightly to 3.6.0 and 2.19.5

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
