### PR TITLE
Fix workflow permissions issue

### DIFF
--- a/.github/workflows/nightly-playground-trigger.yml
+++ b/.github/workflows/nightly-playground-trigger.yml
@@ -8,6 +8,9 @@ on:
 jobs:   
   deploy-nightly-playground:
     if: github.repository == 'opensearch-project/opensearch-devops'
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         dist_version: ['2.19.6', '3.7.0']


### PR DESCRIPTION
### Description
Fix workflow permissions issue. The validate-and-deploy job uses aws-actions/configure-aws-credentials` with role-to-assume . This authenticates to AWS using GitHub's OIDC provider — the action requests an OIDC token from GitHub and exchanges it with AWS STS to assume the IAM role. Generating that OIDC token requires the id-token: write permission.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
